### PR TITLE
Cookie capture, expiry status, and file dialog path fixes

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,6 +1,7 @@
 import json
 import os
 import shutil
+import sys
 import threading
 import time
 from email.utils import parsedate_to_datetime  # WebView2 hands back RFC-date expiry strings
@@ -12,6 +13,9 @@ from pinterest_dl import PinterestMedia
 
 from core import events
 from core.scrape_config import ScrapeConfig
+
+
+_EXE_DIR = str(Path(sys.executable).parent)
 
 
 class Api:
@@ -292,7 +296,7 @@ class Api:
 
         target = self._file_dialog(
             webview.FileDialog.SAVE,
-            directory=".",
+            directory=_EXE_DIR,
             save_filename="cookies.json",
             file_types=("JSON File (*.json)", "All files (*.*)"),
         )
@@ -406,7 +410,7 @@ class Api:
 
     def select_cache_file(self, default_path: str = "") -> str:
         """Save-file dialog: where to write the metadata cache JSON."""
-        target = Path(default_path) if default_path.strip() else Path("metadata.json")
+        target = Path(default_path) if default_path.strip() else Path(_EXE_DIR) / "metadata.json"
         return self._file_dialog(
             webview.FileDialog.SAVE,
             directory=str(target.parent),
@@ -416,7 +420,7 @@ class Api:
 
     def select_json_file(self, default_path: str = "") -> str:
         """Open-file dialog: pick an existing cache JSON for Download mode."""
-        start = Path(default_path.strip()) if default_path.strip() else Path(".")
+        start = Path(default_path.strip()) if default_path.strip() else Path(_EXE_DIR)
         directory = str(start.parent if start.suffix else start)
         return self._file_dialog(
             webview.FileDialog.OPEN,
@@ -426,11 +430,11 @@ class Api:
 
     def select_folder(self, default_path: str = "") -> str:
         """Folder dialog: pick the output directory."""
-        return self._file_dialog(webview.FileDialog.FOLDER, directory=default_path.strip() or ".")
+        return self._file_dialog(webview.FileDialog.FOLDER, directory=default_path.strip() or _EXE_DIR)
 
     def select_file(self, default_path: str = "") -> str:
         """Open-file dialog: pick any file (used for ffmpeg executable, cookies JSON, etc.)."""
-        start = Path(default_path.strip()) if default_path.strip() else Path(".")
+        start = Path(default_path.strip()) if default_path.strip() else Path(_EXE_DIR)
         directory = str(start.parent if start.is_file() else start)
         return self._file_dialog(
             webview.FileDialog.OPEN, directory=directory, file_types=("All files (*.*)",)

--- a/api.py
+++ b/api.py
@@ -302,6 +302,32 @@ class Api:
         Path(target).write_text(json.dumps(cookies, indent=2), encoding="utf-8")
         return {"success": True, "path": target, "message": f"Saved {len(cookies)} cookies."}
 
+    def check_cookie_status(self, path: str) -> dict:
+        """Report whether a saved cookies JSON is still valid based on stored expiry.
+
+        Args:
+            path (str): The path to the cookies JSON file.
+
+        Returns:
+            dict: {"state": "valid"|"expired"|"unknown", "expiry": int|None}
+            - "valid" means the cookies are not expired as of the check time.
+            - "expired" means the cookies are expired as of the check time.
+            - "unknown" means the cookies could not be loaded or have no expiry info.
+        """
+        try:
+            cookies = json.loads(Path(path).read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return {"state": "unknown", "expiry": None}
+
+        # Session is only as good as its earliest-expiring cookie; ignore session cookies (no expiry).
+        expiries = [c["expiry"] for c in cookies if c.get("expiry")]
+        if not expiries:
+            return {"state": "unknown", "expiry": None}
+
+        earliest = min(expiries)
+        state = "expired" if earliest <= int(time.time()) else "valid"
+        return {"state": state, "expiry": earliest}
+
     @staticmethod
     def _cookie_domain(cookie: SimpleCookie) -> str:
         # pywebview returns http.cookies.SimpleCookie, one morsel each

--- a/api.py
+++ b/api.py
@@ -2,6 +2,9 @@ import json
 import os
 import shutil
 import threading
+import time
+from email.utils import parsedate_to_datetime  # WebView2 hands back RFC-date expiry strings
+from http.cookies import SimpleCookie
 from pathlib import Path
 
 import webview
@@ -187,7 +190,9 @@ class Api:
                         ffmpeg_dir = str(Path(str(ffmpeg["path"])).parent)
                         path_entries = os.environ.get("PATH", "").split(os.pathsep)
                         if ffmpeg_dir not in path_entries:
-                            os.environ["PATH"] = ffmpeg_dir + os.pathsep + os.environ.get("PATH", "")
+                            os.environ["PATH"] = (
+                                ffmpeg_dir + os.pathsep + os.environ.get("PATH", "")
+                            )
 
                 # === download phase ===
                 total = len(media_list)
@@ -230,6 +235,108 @@ class Api:
         finally:
             self._stop.clear()  # ensure reset for the next run, even if this one errored out
             self._thread = None  # mark no active run
+
+    def capture_cookies(self) -> dict:
+        """
+        Open a Pinterest login window, wait for the auth cookie, and save it as a cookies JSON.
+        Runs on the `js_api` worker thread;
+        blocking here is fine and keeps the GUI responsive.
+
+        Returns:
+            dict: {"success": bool, "path": str, "message": str}
+        """
+        if self._window is None:
+            return {"success": False, "path": "", "message": "Window not initialized."}
+
+        login_window = webview.create_window(
+            "Login to Pinterest",
+            "https://www.pinterest.com/login/",
+            width=520,
+            height=720,
+        )
+        if login_window is None:
+            return {"success": False, "path": "", "message": "Failed to create login window."}
+
+        # The user may give up and close the window. Treat that as a clean cancel rather than an error.
+        closed = threading.Event()
+        login_window.events.closed += lambda: closed.set()
+
+        cookies: list[dict] = []
+        deadline = time.monotonic() + 300  # 5 min cap so a walked-away user can't hang the thread
+        while not closed.is_set() and time.monotonic() < deadline:
+            try:
+                raw = (
+                    login_window.get_cookies()
+                )  # blocks until cookies are available or the window is closed
+            except Exception:
+                break  # window torn down mid-call. Closed handler will also fire.
+
+            if self._is_authenticated(raw):
+                for cookie in raw:
+                    if "pinterest.com" in self._cookie_domain(cookie):
+                        cookies.append(self._to_pdl_cookie(cookie))
+                break
+
+            # poll every second until we see the auth cookie or the window is closed
+            time.sleep(1.0)
+
+        if not closed.is_set():
+            login_window.destroy()  # close the login window if it's still open
+
+        if not cookies:
+            return {
+                "success": False,
+                "path": "",
+                "message": "Login cancelled or authentication failed.",
+            }
+
+        target = self._file_dialog(
+            webview.FileDialog.SAVE,
+            directory=".",
+            save_filename="cookies.json",
+            file_types=("JSON File (*.json)", "All files (*.*)"),
+        )
+        if not target:
+            return {"success": False, "path": "", "message": "Save cancelled."}
+
+        Path(target).write_text(json.dumps(cookies, indent=2), encoding="utf-8")
+        return {"success": True, "path": target, "message": f"Saved {len(cookies)} cookies."}
+
+    @staticmethod
+    def _cookie_domain(cookie: SimpleCookie) -> str:
+        # pywebview returns http.cookies.SimpleCookie, one morsel each
+        _, morsel = next(iter(cookie.items()))
+        return morsel["domain"] or ""
+
+    @staticmethod
+    def _is_authenticated(cookies: list[SimpleCookie]) -> bool:
+        # _pinterest_sess exists for anonymous visitors too; _auth=1 is the real login flag
+        for cookie in cookies:
+            name, morsel = next(iter(cookie.items()))
+            if name == "_auth" and morsel.value == "1":
+                return True
+        return False
+
+    @staticmethod
+    def _to_pdl_cookie(cookie: SimpleCookie) -> dict:
+        # map a SimpleCookie morsel to pinterest-dl's on-disk format (CookieJar.from_cookies)
+        name, morsel = next(iter(cookie.items()))
+        expires = morsel["expires"]
+        expiry = None
+        if expires:
+            try:
+                expiry = int(parsedate_to_datetime(expires).timestamp())
+            except (TypeError, ValueError):
+                pass  # if the date is malformed, just omit the expiry rather than failing outright
+
+        return {
+            "name": name,
+            "value": morsel.value,
+            "domain": morsel["domain"],
+            "path": morsel["path"] or "/",
+            "secure": bool(morsel["secure"]),
+            "expiry": expiry,
+        }
 
     def get_core_version(self) -> str:
         """Get the version of the embedded pinterest-dl core."""
@@ -299,4 +406,6 @@ class Api:
         """Open-file dialog: pick any file (used for ffmpeg executable, cookies JSON, etc.)."""
         start = Path(default_path.strip()) if default_path.strip() else Path(".")
         directory = str(start.parent if start.is_file() else start)
-        return self._file_dialog(webview.FileDialog.OPEN, directory=directory, file_types=("All files (*.*)",))
+        return self._file_dialog(
+            webview.FileDialog.OPEN, directory=directory, file_types=("All files (*.*)",)
+        )

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -9,6 +9,11 @@ export interface CaptureCookiesResult {
     message: string;
 }
 
+export interface CookieStatusResult {
+    state: "valid" | "expired" | "unknown";
+    expiry: number | null; // Unix seconds of the earliest-expiring cookie, or null when unknown
+}
+
 export type RunEvent = 
     | { type: "progress"; phase: "scrape" | "download"; current: number; total: number }
     | { type: "log"; level: "info" | "warn" | "error"; message: string }
@@ -41,6 +46,7 @@ export interface PinterestApi {
     get_core_version(): Promise<string>;
     check_ffmpeg(customPath: string | null): Promise<FfmpegResult>;
     capture_cookies(): Promise<CaptureCookiesResult>;
+    check_cookie_status(path: string): Promise<CookieStatusResult>;
     start_run(config: RunPayload): Promise<{ started: boolean;}>;
     terminate(): Promise<void>;
     select_cache_file(defaultPath: string): Promise<string>;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3,6 +3,12 @@ export interface FfmpegResult {
     path: string;
 }
 
+export interface CaptureCookiesResult {
+    success: boolean;
+    path: string;
+    message: string;
+}
+
 export type RunEvent = 
     | { type: "progress"; phase: "scrape" | "download"; current: number; total: number }
     | { type: "log"; level: "info" | "warn" | "error"; message: string }
@@ -34,6 +40,7 @@ export interface RunPayload {
 export interface PinterestApi {
     get_core_version(): Promise<string>;
     check_ffmpeg(customPath: string | null): Promise<FfmpegResult>;
+    capture_cookies(): Promise<CaptureCookiesResult>;
     start_run(config: RunPayload): Promise<{ started: boolean;}>;
     terminate(): Promise<void>;
     select_cache_file(defaultPath: string): Promise<string>;

--- a/frontend/src/lib/components/SettingsDialog.svelte
+++ b/frontend/src/lib/components/SettingsDialog.svelte
@@ -28,11 +28,31 @@
     };
     const status = $derived(statusMeta[settings.ffmpegStatus]);
 
+    let capturing = $state(false); // disable capture button + show spinner while in progress
+
     async function browseCookies() {
         const api = getApi();
         if (!api) return;
         const path = await api.select_json_file(settings.cookies);
         if (path) settings.cookies = path;
+    }
+
+    async function captureCookies() {
+        const api = getApi();
+        if (!api) return;
+        capturing = true;
+        try {
+            const result = await api.capture_cookies();
+            if (result.success) {
+                settings.cookies = result.path;
+            } else {
+                console.warn(`Cookie capture failed: ${result.message}`); // non-critical, so just log it
+            }
+        } catch (err) {
+            console.error(`Unexpected error: ${err instanceof Error ? err.message : String(err)}`);
+        } finally {
+            capturing = false; // re-enable button regardless of outcome
+        }
     }
 
     async function browseFfmpeg() {
@@ -92,10 +112,22 @@
                         />
                         <Button
                             variant="outline"
-                            class="shrink-0 rounded-l-none"
+                            class="shrink-0 rounded-none"
                             onclick={browseCookies}
                         >
                             <FolderOpen />
+                        </Button>
+                        <Button
+                            variant="outline"
+                            class="shrink-0 rounded-l-none"
+                            onclick={captureCookies}
+                            disabled={capturing}
+                        >
+                            {#if capturing}
+                                <LoaderCircle class="animate-spin" />
+                            {:else}
+                                <KeyRound />
+                            {/if}
                         </Button>
                     </div>
                 </div>

--- a/frontend/src/lib/components/SettingsDialog.svelte
+++ b/frontend/src/lib/components/SettingsDialog.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
     import { cn } from '$lib/utils';
     import { getApi } from '$lib/api';
-    import { settings, checkFfmpeg, type FfmpegStatus } from '$lib/state/settings.svelte';
+    import {
+        settings,
+        checkFfmpeg,
+        checkCookieStatus,
+        type FfmpegStatus,
+        type CookieStatus
+    } from '$lib/state/settings.svelte';
     import * as Dialog from '$lib/components/ui/dialog';
     import { Button } from '$lib/components/ui/button';
     import { Input } from '$lib/components/ui/input';
@@ -28,13 +34,32 @@
     };
     const status = $derived(statusMeta[settings.ffmpegStatus]);
 
+    const cookieMeta: Record<CookieStatus, { label: string; class: string }> = {
+        valid: { label: 'Valid', class: 'bg-success/10 text-success' },
+        expired: { label: 'Expired', class: 'bg-destructive/10 text-destructive' },
+        checking: { label: 'Checking', class: 'bg-muted text-muted-foreground' },
+        unknown: { label: 'Unknown', class: 'bg-muted text-muted-foreground' }
+    };
+    const cookie = $derived(cookieMeta[settings.cookieStatus]);
+
+    function formatExpiry(unixSeconds: number): string {
+        return new Date(unixSeconds * 1000).toLocaleDateString(undefined, {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric'
+        });
+    }
+
     let capturing = $state(false); // disable capture button + show spinner while in progress
 
     async function browseCookies() {
         const api = getApi();
         if (!api) return;
         const path = await api.select_json_file(settings.cookies);
-        if (path) settings.cookies = path;
+        if (path) {
+            settings.cookies = path;
+            await checkCookieStatus();
+        }
     }
 
     async function captureCookies() {
@@ -45,6 +70,7 @@
             const result = await api.capture_cookies();
             if (result.success) {
                 settings.cookies = result.path;
+                await checkCookieStatus();
             } else {
                 console.warn(`Cookie capture failed: ${result.message}`); // non-critical, so just log it
             }
@@ -130,6 +156,36 @@
                             {/if}
                         </Button>
                     </div>
+
+                    {#if settings.cookies}
+                        <div class="flex items-center gap-2">
+                            <Badge class={cn('border-transparent', cookie.class)}>
+                                {#if settings.cookieStatus === 'valid'}
+                                    <CircleCheck />
+                                {:else if settings.cookieStatus === 'expired'}
+                                    <TriangleAlert />
+                                {:else if settings.cookieStatus === 'checking'}
+                                    <LoaderCircle class="animate-spin" />
+                                {:else}
+                                    <CircleQuestionMark />
+                                {/if}
+                                {cookie.label}
+                            </Badge>
+                            {#if settings.cookieStatus === 'expired'}
+                                <span class="text-destructive"
+                                    >Session expired - recapture to refresh.</span
+                                >
+                            {:else if settings.cookieStatus === 'valid' && settings.cookieExpiry}
+                                <span class="text-muted-foreground"
+                                    >Valid until {formatExpiry(settings.cookieExpiry)}</span
+                                >
+                            {:else if settings.cookieStatus === 'unknown'}
+                                <span class="text-muted-foreground"
+                                    >No expiry info - validity unknown.</span
+                                >
+                            {/if}
+                        </div>
+                    {/if}
                 </div>
             </section>
 

--- a/frontend/src/lib/state/settings.svelte.ts
+++ b/frontend/src/lib/state/settings.svelte.ts
@@ -1,9 +1,12 @@
 import { getApi, onBridgeReady } from "$lib/api";
 
 export type FfmpegStatus = "unknown" | "checking" | "found" | "missing";
+export type CookieStatus = "unknown" | "checking" | "valid" | "expired";
 
 interface Settings {
 	cookies: string;
+	cookieStatus: CookieStatus;
+	cookieExpiry: number | null; // Unix seconds of the earliest-expiring cookie, or null when unknown
 	ffmpegPath: string;
 	ffmpegStatus: FfmpegStatus;
 	ffmpegResolved: string;
@@ -15,6 +18,8 @@ const STORAGE_KEY = "pdl.settings";
 
 export const settings = $state<Settings>({
 	cookies: "",
+	cookieStatus: "unknown",
+	cookieExpiry: null,
 	ffmpegPath: "",
 	ffmpegStatus: "unknown",
 	ffmpegResolved: "",
@@ -51,7 +56,11 @@ $effect.root(() => {
 });
 
 // Auto-check on bridge ready so the dialog never opens showing "Unknown" for the first time.
-onBridgeReady(() => checkFfmpeg());
+// Cookies are restored from localStorage synchronously above, so the path is set by now.
+onBridgeReady(() => {
+	checkFfmpeg();
+	checkCookieStatus();
+});
 
 // Resolve FFmpeg via the Python bridge. Under `vite dev` (no pywebview) the status stays
 // "unknown" so the dev preview still runs; the real check runs inside the packaged app.
@@ -70,5 +79,26 @@ export async function checkFfmpeg(): Promise<void> {
 		// Bridge call failed - surface as missing so the user can fix the path.
 		settings.ffmpegStatus = "missing";
 		settings.ffmpegResolved = "";
+	}
+}
+
+// Check the saved cookies file's expiry via the Python bridge. With no path set (or under
+// `vite dev` without pywebview) the status stays "unknown" so no badge is shown.
+export async function checkCookieStatus(): Promise<void> {
+	const api = getApi();
+	if (!api || !settings.cookies.trim()) {
+		settings.cookieStatus = "unknown";
+		settings.cookieExpiry = null;
+		return;
+	}
+	settings.cookieStatus = "checking";
+	try {
+		const result = await api.check_cookie_status(settings.cookies);
+		settings.cookieStatus = result.state;
+		settings.cookieExpiry = result.expiry;
+	} catch {
+		// Bridge call failed - fall back to unknown rather than a false "expired".
+		settings.cookieStatus = "unknown";
+		settings.cookieExpiry = null;
 	}
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pinterest-dl>=1.2.0, <1.3.0
+pinterest-dl>=1.3.0, <1.4.0
 pywebview==6.2.1
 pillow>=10.0


### PR DESCRIPTION
## Why

Users previously had to locate and supply a Pinterest cookie file manually with no feedback about whether it was still valid. This adds an in-app login flow that captures auth cookies directly from a WebView2 session, an expiry indicator so users know when to recapture, and fixes file dialogs to open at the executable directory instead of the Python process CWD (which is wrong in packaged builds).


## Settings / Cookie UX

- 676654b - adds `Api.capture_cookies()`: opens a Pinterest login window, polls for the `_auth=1` cookie, converts the session to pinterest-dl's on-disk JSON format, then prompts a save dialog -- all without requiring the user to touch DevTools
- f8b9ec6 - adds `Api.check_cookie_status()`: reads a saved cookies JSON and returns `valid`, `expired`, or `unknown` based on the earliest-expiring cookie's Unix timestamp
- f8b9ec6 - adds `CookieStatus` type and `cookieStatus`/`cookieExpiry` fields to the settings state; `checkCookieStatus()` runs at bridge-ready alongside `checkFfmpeg()` so the dialog is never stale on first open
- f8b9ec6 - surfaces a color-coded `Badge` in `SettingsDialog.svelte` (valid/expired/checking/unknown) with a human-readable expiry date or a "recapture" prompt when expired
- 676654b - adds a `KeyRound` capture button next to the existing browse button; shows a spinner during the async login flow and disables itself to prevent double-clicks

## API / Build

- 71f8f66 - introduces `_EXE_DIR` (`Path(sys.executable).parent`) and applies it as the default directory for all four file dialog helpers (`select_cache_file`, `select_json_file`, `select_folder`, `select_file`) so dialogs open at the install location in packaged builds rather than the CWD
- ee14cc2 - bumps `pinterest-dl` version pin to `>=1.3.0, <1.4.0`

## Notes

`capture_cookies` polls every second up to a 5-minute deadline so the GUI stays responsive if the user walks away from the login window. The window-closed event sets a flag that terminates the loop immediately, so a cancelled login is handled cleanly without waiting for the deadline.

Cookie expiry is derived from the RFC-date `expires` field on each morsel using `email.utils.parsedate_to_datetime`; morsels with no expiry (session cookies) are excluded from the minimum calculation. If no expiry info exists at all, the state falls back to `unknown` rather than falsely reporting `valid` or `expired`.
