### PR TITLE
Anchor folder dialog to the executable directory

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,3 +1,4 @@
+import ctypes
 import json
 import os
 import shutil
@@ -15,7 +16,15 @@ from core import events
 from core.scrape_config import ScrapeConfig
 
 
-_EXE_DIR = str(Path(sys.executable).parent)
+def _get_exe_dir() -> str:
+    if sys.platform == "win32":
+        buf = ctypes.create_unicode_buffer(32768)
+        ctypes.windll.kernel32.GetModuleFileNameW(None, buf, len(buf))
+        return str(Path(buf.value).parent)
+    return str(Path(os.path.abspath(sys.argv[0])).parent)
+
+
+_EXE_DIR = _get_exe_dir()
 
 
 class Api:
@@ -430,7 +439,17 @@ class Api:
 
     def select_folder(self, default_path: str = "") -> str:
         """Folder dialog: pick the output directory."""
-        return self._file_dialog(webview.FileDialog.FOLDER, directory=default_path.strip() or _EXE_DIR)
+        path = default_path.strip()
+        if path:
+            resolved = Path(path)
+            if not resolved.is_absolute():
+                resolved = Path(_EXE_DIR) / resolved
+        else:
+            resolved = Path(_EXE_DIR)
+        # Walk up to the nearest existing ancestor so the dialog has a valid starting point.
+        while not resolved.exists() and resolved != resolved.parent:
+            resolved = resolved.parent
+        return self._file_dialog(webview.FileDialog.FOLDER, directory=str(resolved))
 
     def select_file(self, default_path: str = "") -> str:
         """Open-file dialog: pick any file (used for ffmpeg executable, cookies JSON, etc.)."""

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -22,7 +22,8 @@
     });
 
     // --- Resizable left config pane (horizontal split) ------------------------
-    const MIN_LEFT = 360;
+    const DEFAULT_LEFT = 480;
+    const MIN_LEFT = 420;
     const MAX_LEFT = 720;
     const LEFT_WIDTH_KEY = 'pdl.leftWidth';
 
@@ -30,7 +31,7 @@
         return Math.min(MAX_LEFT, Math.max(MIN_LEFT, px));
     }
 
-    let leftWidth = $state(clampLeft(Number(localStorage.getItem(LEFT_WIDTH_KEY)) || 450));
+    let leftWidth = $state(clampLeft(Number(localStorage.getItem(LEFT_WIDTH_KEY)) || DEFAULT_LEFT));
     let dragging = $state(false);
 
     function persistLeftWidth() {


### PR DESCRIPTION
## Why

When packaged, the folder dialog opened relative to the Python process CWD instead of where the app lives, dropping users in the wrong place. Relative or non-existent default paths could also leave the dialog with no valid starting point.

## API

- e4a4bf1 - resolves the executable directory via GetModuleFileNameW on Windows (sys.argv[0] elsewhere) instead of sys.executable, which points at the bundler stub under a PyInstaller onefile build
- e4a4bf1 - select_folder resolves relative default paths against the exe dir and walks up to the nearest existing ancestor, so the dialog always opens somewhere valid

## UI

- 53cdc30 - raises the left config pane minimum to 420 and default to 480 for a roomier starting layout

## Notes

GetModuleFileNameW returns the real .exe path under a PyInstaller onefile build, where sys.executable resolves to the temporary extraction stub. The 32768 buffer covers the Windows extended-length path limit.
