### PR TITLE
feat(build): add onefile, zip, and installer distribution artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,15 +31,34 @@ jobs:
       - name: Install Python dependencies
         run: pip install -r requirements-build.txt
 
-      - name: Build executable
-        run: python build.py --release --version ${{ steps.version.outputs.version }}
+      - name: Build all artifacts
+        # One command builds the standalone zip + installer and the portable
+        # onefile exe. The onefile and standalone passes need separate Nuitka
+        # compiles, but the second reuses the C build cache. Inno Setup is
+        # preinstalled on the windows-latest runner, so ISCC.exe is found
+        # automatically.
+        run: python build.py --onefile --zip --installer --version ${{ steps.version.outputs.version }}
 
-      - name: Package artifact
+      - name: Bundle portable archive
         shell: pwsh
-        # exe keeps its name; bundle it with the license into a versioned zip
-        run: Compress-Archive -Path dist/pinterest-dl.exe, LICENSE -DestinationPath "dist/pinterest-dl-gui_windows_${{ steps.version.outputs.version }}.zip"
+        # The onefile exe ships as a zip alongside the EULA and license so users
+        # can read the terms without running the exe. The standalone zip already
+        # carries these files (bundled by build.py); the portable exe does not.
+        # Stage the files under a folder so the zip extracts cleanly, matching the
+        # standalone zip's layout.
+        env:
+          STEM: pinterest-dl-gui_${{ steps.version.outputs.version }}_x64
+        run: |
+          $dir = "dist/${env:STEM}_portable"
+          New-Item -ItemType Directory -Force -Path $dir | Out-Null
+          Copy-Item "dist/${env:STEM}_portable.exe", EULA.txt, LICENSE -Destination $dir
+          Compress-Archive -Path $dir -DestinationPath "dist/${env:STEM}_portable.zip" -Force
 
       - name: Publish release
         uses: softprops/action-gh-release@v2
+        # The windows-latest runner is x64, so build.py tags artifacts _x64.
         with:
-          files: dist/pinterest-dl-gui_windows_${{ steps.version.outputs.version }}.zip
+          files: |
+            dist/pinterest-dl-gui_${{ steps.version.outputs.version }}_x64.zip
+            dist/pinterest-dl-gui_${{ steps.version.outputs.version }}_x64_setup.exe
+            dist/pinterest-dl-gui_${{ steps.version.outputs.version }}_x64_portable.zip

--- a/EULA.txt
+++ b/EULA.txt
@@ -1,0 +1,49 @@
+END USER LICENSE AGREEMENT
+
+Pinterest Downloader GUI
+
+PLEASE READ THIS AGREEMENT CAREFULLY BEFORE INSTALLING OR USING THIS SOFTWARE.
+By installing or using Pinterest Downloader GUI (the "Software"), you agree to
+be bound by the terms below. If you do not agree, do not install or use the
+Software.
+
+1. Purpose and Scope
+   The Software is an independent tool provided for educational and personal
+   use only. It is not affiliated with, endorsed by, or sponsored by Pinterest
+   or any of its subsidiaries or affiliates.
+
+2. Responsible Use
+   You are solely responsible for how you use the Software. You agree to use it
+   in compliance with all applicable laws and regulations and with the terms of
+   service of any website you access, including Pinterest's Terms of Service
+   (https://developers.pinterest.com/terms/). Automated scraping of a website
+   may conflict with its terms of service; it is your responsibility to verify
+   what you are permitted to do before doing it.
+
+3. Content and Intellectual Property
+   The Software may be used to download media and metadata. You are responsible
+   for ensuring that you have the right to access, download, store, and use any
+   content you obtain through the Software. The authors grant you no rights to
+   any third-party content.
+
+4. No Warranty
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT.
+
+5. Limitation of Liability and Misuse
+   To the maximum extent permitted by applicable law, the authors and
+   contributors shall not be liable for any claim, damages, or other liability,
+   whether in an action of contract, tort, or otherwise, arising from, out of,
+   or in connection with the Software or the use of or other dealings in the
+   Software. The authors disclaim any and all responsibility for misuse of the
+   Software. You use it at your own legal risk.
+
+6. Source Code License
+   The Software's source code is licensed separately under the Apache License,
+   Version 2.0. This Agreement governs your use of the distributed application
+   and does not modify or replace the terms of the Apache License 2.0, a copy of
+   which is included with the Software (see the LICENSE file).
+
+By clicking "I accept" or by installing or using the Software, you acknowledge
+that you have read this Agreement and agree to be bound by its terms.

--- a/README.md
+++ b/README.md
@@ -67,13 +67,49 @@ required:
 
 ## Build a release
 
-Building a standalone executable additionally requires Nuitka, declared in
+Building an executable additionally requires Nuitka, declared in
 `requirements-build.txt`:
 
 ```bash
 pip install -r requirements-build.txt
 python build.py --release --version 1.0.0
 ```
+
+`--release` produces a standalone folder under `dist/app.dist/`. This is the
+recommended build: it runs in place and starts fast.
+
+From that standalone folder you can produce two distribution artifacts:
+
+```bash
+python build.py --zip --version 1.0.0        # dist/pinterest-dl-gui_1.0.0_x64.zip
+python build.py --installer --version 1.0.0  # dist/pinterest-dl-gui_1.0.0_x64_setup.exe
+```
+
+- `--zip` packs the folder into a portable, grab-and-run archive.
+- `--installer` wraps it in a Windows installer (Start Menu shortcut +
+  uninstaller). This requires [Inno Setup](https://jrsoftware.org/isdl.php) 6 or
+  7; the build invokes its `ISCC.exe` compiler with the script in `installer.iss`.
+
+Both flags imply `--release` and can be combined (`--zip --installer`).
+
+For a single portable exe instead, pass `--onefile`:
+
+```bash
+python build.py --onefile --version 1.0.0  # dist/pinterest-dl-gui_1.0.0_x64_portable.exe
+```
+
+The onefile build is one self-contained exe, but it unpacks to a temp directory
+on every launch, so startup is slower than the standalone folder.
+
+To produce every artifact at once, combine the flags:
+
+```bash
+python build.py --onefile --zip --installer --version 1.0.0
+```
+
+The onefile and standalone builds need separate Nuitka compiles (a onefile
+build's `app.dist` holds a DLL payload, not a runnable exe), but the second
+compile reuses Nuitka's C build cache, so it is much cheaper than a cold build.
 
 ## Tech stack
 

--- a/build.py
+++ b/build.py
@@ -1,13 +1,22 @@
 import argparse
+import os
+import platform
 import re
+import shutil
 import subprocess
 import sys
+import zipfile
 from pathlib import Path
 
 ROOT = Path(__file__).parent
 FRONTEND_DIR = ROOT / "frontend"
 WEB_DIR = ROOT / "web"
+DIST_DIR = ROOT / "dist"
+DIST_FOLDER = DIST_DIR / "app.dist"  # Nuitka names the standalone folder after app.py
 PACKAGE_JSON = FRONTEND_DIR / "package.json"
+ISS_SCRIPT = ROOT / "installer.iss"
+EXE_NAME = "pinterest-dl.exe" if sys.platform == "win32" else "pinterest-dl"
+EXE_SUFFIX = ".exe" if sys.platform == "win32" else ""
 NPM = "npm.cmd" if sys.platform == "win32" else "npm"  # npm is a .cmd script on Windows
 
 
@@ -22,6 +31,25 @@ def set_version(version: str) -> None:
         raise RuntimeError(f"could not find a 'version' field in {PACKAGE_JSON}")
     PACKAGE_JSON.write_text(new_text, encoding="utf-8")
     print(f">>> Set frontend version -> {version}")
+
+
+def get_version() -> str:
+    text = PACKAGE_JSON.read_text(encoding="utf-8")
+    match = re.search(r'"version":\s*"([^"]*)"', text)
+    if match is None:
+        raise RuntimeError(f"could not find a 'version' field in {PACKAGE_JSON}")
+    return match.group(1)
+
+
+def arch_tag() -> str:
+    # Nuitka compiles for the host architecture, so label artifacts after the
+    # machine running the build.
+    machine = platform.machine().lower()
+    if machine in ("amd64", "x86_64"):
+        return "x64"
+    if machine in ("arm64", "aarch64"):
+        return "arm64"
+    return machine or "unknown"
 
 
 def build_frontend():
@@ -44,23 +72,29 @@ def _ensure_nuitka() -> None:
         )
 
 
-def build_release(*, console: bool = False) -> None:
+def build_release(*, console: bool = False, one_file: bool = False) -> None:
     _ensure_nuitka()
-    dist_dir = ROOT / "dist"
-    dist_dir.mkdir(exist_ok=True)
+    DIST_DIR.mkdir(exist_ok=True)
 
-    exe_name = "pinterest-dl.exe" if sys.platform == "win32" else "pinterest-dl"
-
+    # --onefile bundles everything into a single exe that unpacks to a temp dir on
+    # every launch (slower startup) but is fully portable. --standalone produces a
+    # folder that runs in place with no unpacking, so it is the faster default.
+    # --onefile implies --standalone; without either, Nuitka builds an accelerated
+    # exe that depends on the local Python install and will not run elsewhere.
     cmd = [
         sys.executable, "-m", "nuitka",
-        "--onefile",
+        "--onefile" if one_file else "--standalone",
         # Auto-confirm tool downloads (e.g. the Windows dependency walker) so
         # non-interactive CI builds do not stall on a prompt and abort.
         "--assume-yes-for-downloads",
         f"--include-data-dir={WEB_DIR}=web",
         f"--include-data-dir={ROOT / 'assets'}=assets",
-        f"--output-dir={dist_dir}",
-        f"--output-filename={exe_name}",
+        # Ship the Apache-2.0 license (required for redistribution) and the EULA
+        # so both are present in the standalone folder and the portable zip.
+        f"--include-data-files={ROOT / 'LICENSE'}=LICENSE",
+        f"--include-data-files={ROOT / 'EULA.txt'}=EULA.txt",
+        f"--output-dir={DIST_DIR}",
+        f"--output-filename={EXE_NAME}",
     ]
 
     if sys.platform == "win32":
@@ -90,7 +124,78 @@ def build_release(*, console: bool = False) -> None:
 
     print(">>> Compiling with Nuitka...")
     subprocess.run(cmd, cwd=ROOT, check=True)
-    print(f">>> Built -> {dist_dir / exe_name}")
+
+    # Standalone builds land in <dist>/app.dist/ alongside their dependencies;
+    # onefile builds emit a single exe directly into <dist>.
+    out_path = DIST_DIR / EXE_NAME if one_file else DIST_FOLDER / EXE_NAME
+    print(f">>> Built -> {out_path}")
+
+
+def build_zip(version: str) -> Path:
+    """Zip the standalone folder into a portable, grab-and-run archive."""
+    if not DIST_FOLDER.is_dir():
+        raise RuntimeError(
+            f"standalone build not found at {DIST_FOLDER}; run a --release build first"
+        )
+
+    stem = f"pinterest-dl-gui_{version}_{arch_tag()}"
+    zip_path = DIST_DIR / f"{stem}.zip"
+    # Nest everything under a clean top-level folder so extracting does not spray
+    # files into the user's current directory.
+    root = Path(stem)
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as archive:
+        for path in sorted(DIST_FOLDER.rglob("*")):
+            if path.is_file():
+                archive.write(path, root / path.relative_to(DIST_FOLDER))
+
+    print(f">>> Zipped -> {zip_path}")
+    return zip_path
+
+
+def _find_iscc() -> Path:
+    found = shutil.which("ISCC")
+    if found is not None:
+        return Path(found)
+
+    # Inno Setup does not add ISCC to PATH by default, so probe its standard
+    # install locations before giving up. Prefer the newest version installed.
+    program_dirs = [
+        Path(os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)")),
+        Path(os.environ.get("ProgramFiles", r"C:\Program Files")),
+    ]
+    for version_dir in ("Inno Setup 7", "Inno Setup 6"):
+        for base in program_dirs:
+            iscc = base / version_dir / "ISCC.exe"
+            if iscc.is_file():
+                return iscc
+
+    raise RuntimeError(
+        "Inno Setup compiler (ISCC.exe) not found. Install Inno Setup 6 or 7 from "
+        "https://jrsoftware.org/isdl.php to build the installer."
+    )
+
+
+def build_installer(version: str) -> Path:
+    """Wrap the standalone folder in an Inno Setup installer (Windows only)."""
+    if sys.platform != "win32":
+        raise RuntimeError("the installer build is only supported on Windows")
+    if not DIST_FOLDER.is_dir():
+        raise RuntimeError(
+            f"standalone build not found at {DIST_FOLDER}; run a --release build first"
+        )
+
+    arch = arch_tag()
+    iscc = _find_iscc()
+    # installer.iss builds its OutputBaseFilename from these defines, so the exe
+    # name stays in sync with the zip produced by build_zip.
+    cmd = [str(iscc), f"/DAppVersion={version}", f"/DArch={arch}", str(ISS_SCRIPT)]
+
+    print(">>> Building installer with Inno Setup...")
+    subprocess.run(cmd, cwd=ROOT, check=True)
+
+    out_path = DIST_DIR / f"pinterest-dl-gui_{version}_{arch}_setup.exe"
+    print(f">>> Installer -> {out_path}")
+    return out_path
 
 
 def main() -> None:
@@ -98,7 +203,24 @@ def main() -> None:
     parser.add_argument(
         "--release",
         action="store_true",
-        help="Also package a single executable with Nuitka after building the frontend",
+        help="Also package the app with Nuitka (standalone folder) after building the frontend",
+    )
+    parser.add_argument(
+        "--onefile",
+        action="store_true",
+        help="Build a single portable exe (slower startup). Independent of "
+        "--release; combine with --zip/--installer to produce every artifact",
+    )
+    parser.add_argument(
+        "--zip",
+        action="store_true",
+        help="Zip the standalone folder into a portable archive (implies --release)",
+    )
+    parser.add_argument(
+        "--installer",
+        action="store_true",
+        help="Build a Windows installer from the standalone folder with Inno Setup "
+        "(implies --release)",
     )
     parser.add_argument(
         "--console",
@@ -110,11 +232,32 @@ def main() -> None:
         help="Write this version into frontend/package.json before building",
     )
     args = parser.parse_args()
+
     if args.version:
         set_version(args.version)
     build_frontend()
-    if args.release:
-        build_release(console=args.console)
+
+    # --onefile and the standalone folder need separate Nuitka compiles: a onefile
+    # build's app.dist holds a DLL payload, not a runnable exe, so it cannot be
+    # reused for --zip/--installer. The second compile reuses Nuitka's C build cache
+    # in app.build, so it is far cheaper than a cold build. Build onefile first so
+    # the standalone pass leaves a runnable app.dist on disk for --release.
+    if args.onefile:
+        build_release(console=args.console, one_file=True)
+        # Give the portable exe the same name scheme as the zip/installer instead
+        # of the bare pinterest-dl.exe that Nuitka emits.
+        portable = DIST_DIR / f"pinterest-dl-gui_{get_version()}_{arch_tag()}_portable{EXE_SUFFIX}"
+        portable.unlink(missing_ok=True)
+        (DIST_DIR / EXE_NAME).rename(portable)
+        print(f">>> Portable exe -> {portable}")
+
+    if args.release or args.zip or args.installer:
+        build_release(console=args.console, one_file=False)
+        version = get_version()
+        if args.zip:
+            build_zip(version)
+        if args.installer:
+            build_installer(version)
 
 
 if __name__ == "__main__":

--- a/installer.iss
+++ b/installer.iss
@@ -1,0 +1,50 @@
+#ifndef AppVersion
+  #define AppVersion "0.0.0"
+#endif
+
+#ifndef Arch
+  #define Arch "x64"
+#endif
+
+#define AppName "Pinterest Downloader GUI"
+#define AppExeName "pinterest-dl.exe"
+#define AppPublisher "Zeke Zhang"
+#define AppURL "https://github.com/sean1832/pinterest-dl-gui"
+
+[Setup]
+; AppId uniquely identifies the app for upgrades and uninstall. Keep it stable.
+AppId={{B7E4D2A1-9C3F-4E8A-A6D5-1F2E3C4B5A60}
+AppName={#AppName}
+AppVersion={#AppVersion}
+AppPublisher={#AppPublisher}
+AppPublisherURL={#AppURL}
+AppSupportURL={#AppURL}
+DefaultDirName={autopf}\Pinterest Downloader GUI
+DefaultGroupName=Pinterest Downloader GUI
+DisableProgramGroupPage=yes
+LicenseFile=EULA.txt
+OutputDir=dist
+OutputBaseFilename=pinterest-dl-gui_{#AppVersion}_{#Arch}_setup
+UninstallDisplayIcon={app}\{#AppExeName}
+Compression=lzma2
+SolidCompression=yes
+WizardStyle=modern
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+
+[Files]
+Source: "dist\app.dist\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{group}\{#AppName}"; Filename: "{app}\{#AppExeName}"
+Name: "{group}\Uninstall {#AppName}"; Filename: "{uninstallexe}"
+Name: "{autodesktop}\{#AppName}"; Filename: "{app}\{#AppExeName}"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\{#AppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(AppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,4 +1,4 @@
 # Build-only dependencies for producing a release executable.
 # Includes the runtime deps plus the Nuitka compiler.
 -r requirements.txt
-nuitka
+nuitka==4.1.2


### PR DESCRIPTION
## Why

The release pipeline previously produced a single bare exe. This adds three distinct artifacts -- a portable standalone zip, a Windows installer, and a single-file portable exe -- so users can choose the distribution that fits their workflow.


## Build

- 509e3ba - adds `--onefile`, `--zip`, and `--installer` flags to `build.py`; combines both Nuitka passes in one invocation and reuses the C build cache on the second pass to minimize compile time
- 509e3ba - adds `build_zip()` in `build.py` to pack `dist/app.dist/` into a versioned, arch-tagged zip with a clean top-level folder so extraction does not spray files
- 509e3ba - adds `build_installer()` in `build.py` to invoke Inno Setup's `ISCC.exe`, probing standard install locations when it is not on PATH
- 509e3ba - adds `arch_tag()` and `get_version()` helpers; all artifact names now carry `_x64` / `_arm64` suffixes derived from `platform.machine()`
- 509e3ba - renames the portable exe to `pinterest-dl-gui_{version}_{arch}_portable.exe` immediately after the onefile Nuitka pass
- 509e3ba - includes `LICENSE` and `EULA.txt` in the Nuitka data file set so both are present in the standalone folder, the zip, and the portable zip
- 8bb61e3 - pins `nuitka==4.1.2` in `requirements-build.txt` to prevent silent regressions from upstream Nuitka releases

## CI

- 509e3ba - updates `release.yml` to call `python build.py --onefile --zip --installer` instead of a single `--release` pass
- 509e3ba - replaces the hand-rolled `Compress-Archive` step with a PowerShell block that stages the portable exe, `EULA.txt`, and `LICENSE` into a named subfolder before zipping, matching the layout of the standalone zip
- 509e3ba - publishes three assets: `_x64.zip`, `_x64_setup.exe`, and `_x64_portable.zip`

## Installer

- 509e3ba - adds `installer.iss` (Inno Setup 6/7 script) that installs from `dist\app.dist\*`, creates a Start Menu group, offers an optional desktop shortcut, and bundles `EULA.txt` as the license screen

## Notes

The onefile and standalone builds cannot share an `app.dist` folder: a onefile pass populates `app.dist` with a DLL payload rather than a runnable exe, so `--onefile` must be compiled first. `--zip` and `--installer` then trigger a separate standalone pass that leaves a clean `app.dist` on disk. The second pass reuses Nuitka's `app.build` C cache, so the extra compile is cheap relative to a cold build.
