### PR TITLE
UI polish: TooltipButton, separators, and cursor-pointer fixes

### DIFF
--- a/frontend/src/lib/components/ConfigPanel.svelte
+++ b/frontend/src/lib/components/ConfigPanel.svelte
@@ -151,21 +151,21 @@
             >
                 <ToggleGroupItem
                     value="scrape"
-                    class="flex-1 gap-1.5 text-muted-foreground data-[state=on]:bg-muted data-[state=on]:text-foreground data-[state=on]:shadow-sm"
+                    class="cursor-pointer flex-1 gap-1.5 text-muted-foreground data-[state=on]:bg-muted data-[state=on]:text-foreground data-[state=on]:shadow-sm"
                 >
                     <Download class="size-3.5" />
                     Scrape
                 </ToggleGroupItem>
                 <ToggleGroupItem
                     value="search"
-                    class="flex-1 gap-1.5 text-muted-foreground data-[state=on]:bg-muted data-[state=on]:text-foreground data-[state=on]:shadow-sm"
+                    class="cursor-pointer flex-1 gap-1.5 text-muted-foreground data-[state=on]:bg-muted data-[state=on]:text-foreground data-[state=on]:shadow-sm"
                 >
                     <Search class="size-3.5" />
                     Search
                 </ToggleGroupItem>
                 <ToggleGroupItem
                     value="download"
-                    class="flex-1 gap-1.5 text-muted-foreground data-[state=on]:bg-muted data-[state=on]:text-foreground data-[state=on]:shadow-sm"
+                    class="cursor-pointer flex-1 gap-1.5 text-muted-foreground data-[state=on]:bg-muted data-[state=on]:text-foreground data-[state=on]:shadow-sm"
                 >
                     <FileDown class="size-3.5" />
                     Download
@@ -230,12 +230,7 @@
                     {#if showLimit}
                         <div class="flex flex-1 flex-col gap-1.5">
                             <Label for="limit">Limit</Label>
-                            <NumberInput
-                                id="limit"
-                                bind:value={run.limit}
-                                min={1}
-                                max={5000}
-                            />
+                            <NumberInput id="limit" bind:value={run.limit} min={1} max={5000} />
                         </div>
                     {/if}
                 </div>
@@ -257,17 +252,9 @@
                         desc="Discard assets smaller than dimensions (0 disables)."
                     >
                         <div class="flex items-center gap-2">
-                            <NumberInput
-                                bind:value={run.resW}
-                                min={0}
-                                class="w-28"
-                            />
+                            <NumberInput bind:value={run.resW} min={0} class="w-28" />
                             <span class="text-muted-foreground">x</span>
-                            <NumberInput
-                                bind:value={run.resH}
-                                min={0}
-                                class="w-28"
-                            />
+                            <NumberInput bind:value={run.resH} min={0} class="w-28" />
                         </div>
                     </OptionRow>
 
@@ -287,10 +274,7 @@
                         </Select.Root>
                     </OptionRow>
 
-                    <OptionRow
-                        title="Strict Alt-Text"
-                        desc="Drop assets lacking valid captions."
-                    >
+                    <OptionRow title="Strict Alt-Text" desc="Drop assets lacking valid captions.">
                         <Switch bind:checked={run.strictAlt} />
                     </OptionRow>
                 </div>

--- a/frontend/src/lib/components/SettingsDialog.svelte
+++ b/frontend/src/lib/components/SettingsDialog.svelte
@@ -16,6 +16,7 @@
     import { Badge } from '$lib/components/ui/badge';
     import { Separator } from '$lib/components/ui/separator';
     import InfoTooltip from '$lib/components/info-tooltip.svelte';
+    import TooltipButton from '$lib/components/tooltip-button.svelte';
     import Settings from '@lucide/svelte/icons/settings';
     import KeyRound from '@lucide/svelte/icons/key-round';
     import Film from '@lucide/svelte/icons/film';
@@ -144,7 +145,8 @@
                         >
                             <FolderOpen />
                         </Button>
-                        <Button
+                        <TooltipButton
+                            tooltip="Capture a new cookies from Pinterest by logging in through an embedded browser window."
                             variant="outline"
                             class="shrink-0 rounded-l-none"
                             onclick={captureCookies}
@@ -155,7 +157,7 @@
                             {:else}
                                 <KeyRound />
                             {/if}
-                        </Button>
+                        </TooltipButton>
                     </div>
 
                     {#if settings.cookies}
@@ -226,14 +228,15 @@
                             {settings.ffmpegResolved || 'Not resolved'}
                         </span>
                     </div>
-                    <Button
+                    <TooltipButton
+                        tooltip="Re-check FFmpeg availability"
                         variant="outline"
                         size="sm"
                         class="shrink-0"
                         onclick={() => checkFfmpeg()}
                     >
                         <RefreshCw />
-                    </Button>
+                    </TooltipButton>
                 </div>
                 <div class="flex flex-col gap-1.5">
                     <Label for="set-ffmpeg">Custom FFmpeg Path</Label>

--- a/frontend/src/lib/components/SettingsDialog.svelte
+++ b/frontend/src/lib/components/SettingsDialog.svelte
@@ -14,6 +14,7 @@
     import { NumberInput } from '$lib/components/ui/number-input';
     import { Label } from '$lib/components/ui/label';
     import { Badge } from '$lib/components/ui/badge';
+    import { Separator } from '$lib/components/ui/separator';
     import InfoTooltip from '$lib/components/info-tooltip.svelte';
     import Settings from '@lucide/svelte/icons/settings';
     import KeyRound from '@lucide/svelte/icons/key-round';
@@ -189,6 +190,8 @@
                 </div>
             </section>
 
+            <Separator />
+
             <!-- Video / FFmpeg -->
             <section class="flex flex-col gap-3">
                 <div class="flex items-center gap-1.5">
@@ -252,6 +255,8 @@
                     </div>
                 </div>
             </section>
+
+            <Separator />
 
             <!-- Network -->
             <section class="flex flex-col gap-3">

--- a/frontend/src/lib/components/tooltip-button.svelte
+++ b/frontend/src/lib/components/tooltip-button.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import * as Tooltip from "$lib/components/ui/tooltip";
+	import { Button, type ButtonProps } from "$lib/components/ui/button";
+
+	let { tooltip, children, ...rest }: ButtonProps & { tooltip: string } = $props();
+</script>
+
+<Tooltip.Provider>
+	<Tooltip.Root>
+		<Tooltip.Trigger>
+			{#snippet child({ props })}
+				<Button {...props} {...rest}>{@render children?.()}</Button>
+			{/snippet}
+		</Tooltip.Trigger>
+		<Tooltip.Content sideOffset={6}>{tooltip}</Tooltip.Content>
+	</Tooltip.Root>
+</Tooltip.Provider>

--- a/frontend/src/lib/components/ui/button/button.svelte
+++ b/frontend/src/lib/components/ui/button/button.svelte
@@ -4,7 +4,7 @@
 	import { type VariantProps, tv } from "tailwind-variants";
 
 	export const buttonVariants = tv({
-		base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-xs font-medium focus-visible:ring-1 active:not-aria-[haspopup]:translate-y-px aria-invalid:ring-1 [&_svg:not([class*='size-'])]:size-4 group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		base: "cursor-pointer focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-xs font-medium focus-visible:ring-1 active:not-aria-[haspopup]:translate-y-px aria-invalid:ring-1 [&_svg:not([class*='size-'])]:size-4 group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		variants: {
 			variant: {
 				default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",

--- a/frontend/src/lib/components/ui/number-input/number-input.svelte
+++ b/frontend/src/lib/components/ui/number-input/number-input.svelte
@@ -20,7 +20,7 @@
         step = 1,
         disabled = false,
         class: className,
-        id,
+        id
     }: Props = $props();
 
     function clamp(v: number): number {
@@ -70,7 +70,7 @@
             onclick={increment}
             disabled={disabled || atMax}
             tabindex="-1"
-            class="flex flex-1 w-5 items-center justify-center text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
+            class="cursor-pointer flex flex-1 w-5 items-center justify-center text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
         >
             <ChevronUp class="size-3" />
         </button>
@@ -80,7 +80,7 @@
             onclick={decrement}
             disabled={disabled || atMin}
             tabindex="-1"
-            class="flex flex-1 w-5 items-center justify-center text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
+            class="cursor-pointer flex flex-1 w-5 items-center justify-center text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
         >
             <ChevronDown class="size-3" />
         </button>

--- a/frontend/src/lib/components/ui/switch/switch.svelte
+++ b/frontend/src/lib/components/ui/switch/switch.svelte
@@ -19,13 +19,13 @@
 	data-slot="switch"
 	data-size={size}
 	class={cn(
-		"data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-1 aria-invalid:ring-1 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] peer group/switch relative inline-flex items-center transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+		"cursor-pointer data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-1 aria-invalid:ring-1 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] peer group/switch relative inline-flex items-center transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 data-disabled:cursor-not-allowed data-disabled:opacity-50",
 		className
 	)}
 	{...restProps}
 >
 	<SwitchPrimitive.Thumb
 		data-slot="switch-thumb"
-		class="bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 pointer-events-none block ring-0 transition-transform rtl:data-[state=checked]:translate-x-[calc(-100%)]"
+		class="cursor-pointer bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 pointer-events-none block ring-0 transition-transform rtl:data-[state=checked]:translate-x-[calc(-100%)]"
 	/>
 </SwitchPrimitive.Root>


### PR DESCRIPTION
## Why

Interactive elements across the settings and config UI were missing `cursor-pointer`, making them feel unclickable. Icon-only buttons in SettingsDialog also lacked any hint of what they do. This batch tightens the interaction model so every clickable element gives clear affordance.


## UI

- f9c3778 - adds `Separator` between the Cookies, Video/FFmpeg, and Network sections in `SettingsDialog.svelte` to visually group unrelated settings
- 47cd7fa - introduces `tooltip-button.svelte`, a thin wrapper that composes shadcn `Button` inside a `Tooltip.Root` via the `child` snippet pattern; replaces the bare capture-cookies and re-check-FFmpeg buttons with `TooltipButton` so their purpose is visible on hover
- d725dc5 - adds `cursor-pointer` to the base class of `button.svelte`, both stepper buttons in `number-input.svelte`, the switch root and thumb in `switch.svelte`, and each `ToggleGroupItem` in `ConfigPanel.svelte`
