### PR TITLE
Parallel downloads, structured run logging, and console polish

### DIFF
--- a/api.py
+++ b/api.py
@@ -82,6 +82,10 @@ class Api:
 
         res_w, res_h = config["min_resolution"]  # JS sends [w, h]; unpack asserts length 2 at runt
 
+        # Cap concurrency at the boundary so a bad/forged payload can't spawn a thread storm
+        # (and going past the shared HTTP pool size of 10 only churns connections anyway).
+        max_workers = max(1, min(16, int(config.get("max_workers", 8))))
+
         scrape_config = ScrapeConfig(
             url=url,
             mode=mode,
@@ -90,6 +94,7 @@ class Api:
             min_resolution=(int(res_w), int(res_h)),
             delay=float(config["delay"]),
             timeout=float(config.get("timeout", 10.0)),
+            max_workers=max_workers,
             cookies=(str(config.get("cookies", "")).strip() or None),
             ensure_alt=bool(config.get("ensure_alt", False)),
             ffmpeg_path=(str(config.get("ffmpeg_path", "")).strip() or None),
@@ -244,26 +249,27 @@ class Api:
                 self._emit(events.log("info", f"Downloading {total} files to {config.output_dir}"))
                 self._emit(events.progress("download", 0, total))  # flip phase label to Downloading
 
-                # Progress current tracks items processed (index + 1) so the bar still reaches
-                # total when files are skipped; `downloaded` counts only successes.
-                def on_file_downloaded(index: int, media: PinterestMedia):
+                # `completed` is the running count of finished files (successes + failures), so
+                # the bar still reaches total when files are skipped; `downloaded` counts only
+                # successes. With concurrent downloads, callbacks fire in completion order.
+                def on_file_downloaded(completed: int, media: PinterestMedia):
                     nonlocal downloaded, videos
                     downloaded += 1
                     is_video_file = download_streams and media.video_stream is not None
                     if is_video_file:
                         videos += 1
-                    self._emit(events.progress("download", index + 1, total))
+                    self._emit(events.progress("download", completed, total))
                     # Preview the file just written to disk; a video stream has no still to show.
                     thumbnail = "" if is_video_file else thumbnail_data_uri(media.local_path)
                     self._emit(events.media(thumbnail, is_video_file))
 
-                def on_file_failed(index: int, media: PinterestMedia, exc: Exception):
+                def on_file_failed(completed: int, media: PinterestMedia, exc: Exception):
                     nonlocal failed
                     failed += 1
                     self._emit(
                         events.log("warn", f"Skipped {media.id}: {type(exc).__name__}: {exc}")
                     )
-                    self._emit(events.progress("download", index + 1, total))
+                    self._emit(events.progress("download", completed, total))
 
                 run_download(
                     media_list,
@@ -271,6 +277,7 @@ class Api:
                     Path(config.output_dir),
                     download_streams,
                     config.skip_remux,
+                    config.max_workers,
                     on_file_downloaded,
                     on_file_failed,
                     lambda: self._stop.is_set(),

--- a/api.py
+++ b/api.py
@@ -132,11 +132,13 @@ class Api:
             thumbnail_data_uri,
         )
 
+        self._emit(events.log("info", f"Starting run in '{config.mode}' mode..."))
         # Initialized up front so the cancel/except paths can report partial counts even if
         # never reach the download phase (media_list may not exists there)
         scraped = 0
         downloaded = 0
         videos = 0
+        failed = 0
         saved = 0
         try:
             with events.forward_logs(self._emit):
@@ -148,8 +150,13 @@ class Api:
                 if config.mode == "download":
                     if self._stop.is_set():
                         raise events.RunCancelled()
+                    self._emit(events.log("info", f"Loading cache file: {config.url}"))
                     media_list = load_cache(Path(config.url))
                     scraped = len(media_list)
+                    if scraped == 0:
+                        self._emit(events.log("warn", "Cache file contains no records."))
+                    else:
+                        self._emit(events.log("info", f"Loaded {scraped} records from cache."))
                 else:
                     scraper = PinterestDL.with_api(
                         timeout=config.timeout, ensure_alt=config.ensure_alt
@@ -158,6 +165,7 @@ class Api:
                     # raises here and surfaces as a run error rather than failing silently.
                     if config.cookies:
                         scraper.with_cookies_path(config.cookies)
+                        self._emit(events.log("info", f"Using cookies: {config.cookies}"))
 
                     def on_progress(media):
                         nonlocal scraped
@@ -167,11 +175,34 @@ class Api:
                         self._emit(events.progress("scrape", scraped, config.num))
 
                     if config.mode == "scrape":
+                        self._emit(
+                            events.log(
+                                "info", f"Scraping up to {config.num} items from {config.url}"
+                            )
+                        )
                         media_list = run_api_scrape(scraper, config, on_progress)
                     elif config.mode == "search":
+                        self._emit(
+                            events.log(
+                                "info", f"Searching '{config.url}' for up to {config.num} items"
+                            )
+                        )
                         media_list = run_api_search(scraper, config, on_progress)
                     else:
                         raise ValueError(f"Unsupported mode: {config.mode}")
+
+                    if scraped == 0:
+                        # The most common silent failure: bad URL/query, or missing/expired
+                        # cookies for a private board. Flag it instead of reporting a clean run.
+                        self._emit(
+                            events.log(
+                                "warn",
+                                "No media found. Check the URL/query, or your cookies for "
+                                "private boards.",
+                            )
+                        )
+                    else:
+                        self._emit(events.log("info", f"Scraped {scraped} media items."))
 
                     # === optionally persist the scraped records for later reuse ===
                     if config.save_cache:
@@ -206,21 +237,33 @@ class Api:
                             os.environ["PATH"] = (
                                 ffmpeg_dir + os.pathsep + os.environ.get("PATH", "")
                             )
+                            self._emit(events.log("info", f"Using ffmpeg: {ffmpeg['path']}"))
 
                 # === download phase ===
                 total = len(media_list)
+                self._emit(events.log("info", f"Downloading {total} files to {config.output_dir}"))
                 self._emit(events.progress("download", 0, total))  # flip phase label to Downloading
 
+                # Progress current tracks items processed (index + 1) so the bar still reaches
+                # total when files are skipped; `downloaded` counts only successes.
                 def on_file_downloaded(index: int, media: PinterestMedia):
                     nonlocal downloaded, videos
-                    downloaded = index + 1
+                    downloaded += 1
                     is_video_file = download_streams and media.video_stream is not None
                     if is_video_file:
                         videos += 1
-                    self._emit(events.progress("download", downloaded, total))
+                    self._emit(events.progress("download", index + 1, total))
                     # Preview the file just written to disk; a video stream has no still to show.
                     thumbnail = "" if is_video_file else thumbnail_data_uri(media.local_path)
                     self._emit(events.media(thumbnail, is_video_file))
+
+                def on_file_failed(index: int, media: PinterestMedia, exc: Exception):
+                    nonlocal failed
+                    failed += 1
+                    self._emit(
+                        events.log("warn", f"Skipped {media.id}: {type(exc).__name__}: {exc}")
+                    )
+                    self._emit(events.progress("download", index + 1, total))
 
                 run_download(
                     media_list,
@@ -229,10 +272,16 @@ class Api:
                     download_streams,
                     config.skip_remux,
                     on_file_downloaded,
+                    on_file_failed,
                     lambda: self._stop.is_set(),
                 )
                 if self._stop.is_set():  # cancelled between files
                     raise events.RunCancelled()
+
+                summary = f"Downloaded {downloaded} files ({videos} videos)"
+                if failed:
+                    summary += f", {failed} skipped"
+                self._emit(events.log("info", summary + "."))
 
                 # === captions: write sidecars / embed EXIF for the downloaded files ===
                 if config.caption != "none":
@@ -313,6 +362,7 @@ class Api:
             return {"success": False, "path": "", "message": "Save cancelled."}
 
         Path(target).write_text(json.dumps(cookies, indent=2), encoding="utf-8")
+        self._emit(events.log("info", f"Captured {len(cookies)} cookies and saved to {target}"))
         return {"success": True, "path": target, "message": f"Saved {len(cookies)} cookies."}
 
     def check_cookie_status(self, path: str) -> dict:

--- a/core/downloader.py
+++ b/core/downloader.py
@@ -85,14 +85,23 @@ def run_download(
     download_videos: bool,
     skip_remux: bool,
     on_file_downloaded: Callable[[int, PinterestMedia], None],
+    on_file_failed: Callable[[int, PinterestMedia, Exception], None],
     should_cancel: Callable[[], bool],
 ) -> List[Path]:
-    """Download each scraped media in order, reporting and checking cancel between files."""
+    """Download each scraped media in order, reporting and checking cancel between files.
+
+    A single file failing (dead/stale Pinterest URL, network error) is reported via
+    on_file_failed and skipped, so one bad pin does not abort the whole batch.
+    """
     downloaded_paths: List[Path] = []
     for i, media in enumerate(media_list):
         if should_cancel():  # checked before each file -> Terminate stops within one item
             break
-        result = downloader.download(media, output_dir, download_videos, skip_remux)
+        try:
+            result = downloader.download(media, output_dir, download_videos, skip_remux)
+        except Exception as e:
+            on_file_failed(i, media, e)  # warn + advance progress, then move on
+            continue
         media.set_local_path(result)  # captioning reads local_path to find the saved file
         downloaded_paths.append(result)
         on_file_downloaded(i, media)  # drives download-phase progress + the live videos tally

--- a/core/downloader.py
+++ b/core/downloader.py
@@ -1,4 +1,5 @@
 import base64
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from io import BytesIO
 from pathlib import Path
@@ -79,32 +80,55 @@ def load_cache(path: Path) -> List[PinterestMedia]:
 
 
 def run_download(
-    media_list: List[PinterestMedia],
+    media_list: Sequence[PinterestMedia],
     downloader: MediaDownloader,
     output_dir: Path,
     download_videos: bool,
     skip_remux: bool,
+    max_workers: int,
     on_file_downloaded: Callable[[int, PinterestMedia], None],
     on_file_failed: Callable[[int, PinterestMedia, Exception], None],
     should_cancel: Callable[[], bool],
 ) -> List[Path]:
-    """Download each scraped media in order, reporting and checking cancel between files.
+    """Download scraped media concurrently, reporting completions on the calling thread.
 
-    A single file failing (dead/stale Pinterest URL, network error) is reported via
-    on_file_failed and skipped, so one bad pin does not abort the whole batch.
+    Downloads run on a thread pool, but callbacks fire here as futures complete, not in
+    worker threads -- so counter mutation and event emission stay single-threaded and need
+    no locks. `completed` is the running 1-based count, since completions arrive out of order.
+
+    A single file failing is reported via on_file_failed and skipped, so one bad pin does
+    not abort the batch. Cancellation drops un-started downloads; in-flight ones run to
+    completion since a blocking download can't be interrupted.
     """
     downloaded_paths: List[Path] = []
-    for i, media in enumerate(media_list):
-        if should_cancel():  # checked before each file -> Terminate stops within one item
-            break
-        try:
-            result = downloader.download(media, output_dir, download_videos, skip_remux)
-        except Exception as e:
-            on_file_failed(i, media, e)  # warn + advance progress, then move on
-            continue
-        media.set_local_path(result)  # captioning reads local_path to find the saved file
-        downloaded_paths.append(result)
-        on_file_downloaded(i, media)  # drives download-phase progress + the live videos tally
+    if not media_list:
+        return downloaded_paths
+
+    completed = 0
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        future_to_media = {
+            executor.submit(
+                downloader.download, media, output_dir, download_videos, skip_remux
+            ): media
+            for media in media_list
+        }
+        for future in as_completed(future_to_media):
+            if should_cancel():
+                # Drop everything not yet started; in-flight futures still finish as the
+                # `with` block waits on shutdown. cancel() is a no-op on running futures.
+                for pending in future_to_media:
+                    pending.cancel()
+                break
+            media = future_to_media[future]
+            completed += 1
+            try:
+                result = future.result()
+            except Exception as e:
+                on_file_failed(completed, media, e)  # warn + advance progress, then move on
+                continue
+            media.set_local_path(result)  # captioning reads local_path to find the saved file
+            downloaded_paths.append(result)
+            on_file_downloaded(completed, media)  # drives download progress + live videos tally
     return downloaded_paths
 
 

--- a/core/scrape_config.py
+++ b/core/scrape_config.py
@@ -12,6 +12,7 @@ class ScrapeConfig:
     delay: float
     download_streams: bool
     timeout: float = 10.0  # per-request timeout for both scrape and download
+    max_workers: int = 8  # concurrent download threads; clamped 1-16 at the API boundary
     ensure_alt: bool = False  # strict alt-text: drop assets lacking captions
     # How media is acquired: "scrape"/"search" hit Pinterest; "download" loads a previously
     # saved cache JSON whose path is carried in `url`.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -30,6 +30,7 @@ export interface RunPayload {
     min_resolution: [number, number];
     delay: number;
     timeout?: number;
+    max_workers?: number;
     cookies?: string;
     ensure_alt?: boolean;
     ffmpeg_path?: string;

--- a/frontend/src/lib/components/ConfigPanel.svelte
+++ b/frontend/src/lib/components/ConfigPanel.svelte
@@ -106,6 +106,7 @@
             min_resolution: [run.resW, run.resH],
             delay: settings.delay,
             timeout: settings.timeout,
+            max_workers: settings.maxWorkers,
             cookies: settings.cookies,
             ensure_alt: run.strictAlt,
             ffmpeg_path: settings.ffmpegPath,

--- a/frontend/src/lib/components/ConsolePanel.svelte
+++ b/frontend/src/lib/components/ConsolePanel.svelte
@@ -112,20 +112,22 @@
     <!-- Log -->
     <ScrollArea class="min-h-0 flex-1">
         <div
-            class="flex flex-col gap-1 p-4 font-mono text-[11px] leading-relaxed text-muted-foreground"
+            class="flex flex-col gap-0.5 p-3 font-mono text-[11px] leading-relaxed text-muted-foreground select-text"
         >
             {#each runStatus.logs as log, i (i)}
-                <div class="flex items-center gap-2">
-                    <time class="shrink-0 text-muted-foreground/60">{log.time}</time>
+                <div
+                    class="flex items-center gap-2 rounded px-1.5 py-0.5 transition-colors duration-75 hover:bg-muted/70"
+                >
+                    <time class="shrink-0 text-muted-foreground/60 select-none">{log.time}</time>
                     <Badge
                         class={cn(
-                            'h-4 shrink-0 border-transparent px-1 text-[10px]',
+                            'h-4 shrink-0 border-transparent px-1 text-[10px] select-none',
                             tagClass[logTag(log)]
                         )}
                     >
                         {logTag(log)}
                     </Badge>
-                    <span>{log.message}</span>
+                    <span class="break-all">{log.message}</span>
                 </div>
             {/each}
         </div>

--- a/frontend/src/lib/components/ConsolePanel.svelte
+++ b/frontend/src/lib/components/ConsolePanel.svelte
@@ -10,7 +10,7 @@
 
     const tagClass: Record<string, string> = {
         SYS: 'bg-primary/10 text-primary',
-        DL: 'bg-success/10 text-success',
+        OK: 'bg-success/10 text-success',
         WARN: 'bg-warning/10 text-warning',
         ERR: 'bg-destructive/10 text-destructive'
     };
@@ -19,7 +19,7 @@
     function logTag(line: LogLine): string {
         if (line.level === 'error') return 'ERR';
         if (line.level === 'warn') return 'WARN';
-        if (line.phase === 'download') return 'DL';
+        if (line.phase === 'download') return 'OK';
         return 'SYS';
     }
 

--- a/frontend/src/lib/components/SettingsDialog.svelte
+++ b/frontend/src/lib/components/SettingsDialog.svelte
@@ -294,6 +294,21 @@
                         />
                     </div>
                 </div>
+                <div class="flex flex-col gap-1.5">
+                    <div class="flex items-center gap-1.5">
+                        <Label for="set-max-workers">Max Concurrent Downloads</Label>
+                        <InfoTooltip
+                            text="How many files download in parallel. Higher is faster but higher risk of rate-limiting. (1-16, defaults to 8)"
+                        />
+                    </div>
+                    <NumberInput
+                        id="set-max-workers"
+                        bind:value={settings.maxWorkers}
+                        step={1}
+                        min={1}
+                        max={16}
+                    />
+                </div>
             </section>
         </div>
     </Dialog.Content>

--- a/frontend/src/lib/state/runStatus.svelte.ts
+++ b/frontend/src/lib/state/runStatus.svelte.ts
@@ -66,8 +66,6 @@ function apply(event: RunEvent): void {
             runStatus.phase = event.phase;
             runStatus.current = event.current;
             runStatus.total = event.total;
-            // Downloaded tile is driven by download-phase progress; done reconciles it.
-            if (event.phase === "download") runStatus.counts.downloaded = event.current;
             break;
         case "log":
             runStatus.logs.push({
@@ -79,6 +77,8 @@ function apply(event: RunEvent): void {
             break;
         case "media":
             runStatus.previews.push({ thumbnail: event.thumbnail, isVideo: event.isVideo });
+            // One media event per successful download; skipped files emit none, so this stays exact.
+            runStatus.counts.downloaded += 1;
             if (event.isVideo) runStatus.counts.videos += 1;  // live tally as files download
             break;
         case "done":

--- a/frontend/src/lib/state/settings.svelte.ts
+++ b/frontend/src/lib/state/settings.svelte.ts
@@ -12,6 +12,7 @@ interface Settings {
 	ffmpegResolved: string;
 	delay: number;
 	timeout: number;
+	maxWorkers: number; // concurrent download threads, clamped 1-16 by the Python boundary
 }
 
 const STORAGE_KEY = "pdl.settings";
@@ -25,6 +26,7 @@ export const settings = $state<Settings>({
 	ffmpegResolved: "",
 	delay: 0.2,
 	timeout: 10,
+	maxWorkers: 8,
 });
 
 // Restore durable fields synchronously at module init (before any component renders).
@@ -36,6 +38,7 @@ if (raw) {
 		if (typeof saved.ffmpegPath === "string") settings.ffmpegPath = saved.ffmpegPath;
 		if (typeof saved.delay === "number") settings.delay = saved.delay;
 		if (typeof saved.timeout === "number") settings.timeout = saved.timeout;
+		if (typeof saved.maxWorkers === "number") settings.maxWorkers = saved.maxWorkers;
 	} catch {
 		// Corrupt JSON in localStorage - keep defaults rather than failing startup.
 	}
@@ -50,6 +53,7 @@ $effect.root(() => {
 			ffmpegPath: settings.ffmpegPath,
 			delay: settings.delay,
 			timeout: settings.timeout,
+			maxWorkers: settings.maxWorkers,
 		};
 		localStorage.setItem(STORAGE_KEY, JSON.stringify(durable));
 	});


### PR DESCRIPTION
## Why

Downloads were sequential and silent, one slow pin blocked the rest, and the console gave no feedback about what was actually happening during a run. This adds a thread pool for concurrent downloads, a per-file failure path that skips bad pins without aborting the batch, and detailed log events throughout the scrape/download pipeline so the console becomes a useful diagnostic surface rather than a black box.


## Downloader

- 650d179 - replaces the sequential loop in `run_download` with a `ThreadPoolExecutor`; `as_completed` fires callbacks on the calling thread so counter mutation and event emission stay single-threaded without locks
- 650d179 - adds `on_file_failed` callback and `failed` counter; a single bad pin emits a WARN log and advances the progress bar, then moves on -- the batch no longer aborts
- 650d179 - cancellation via `should_cancel` drops un-started futures; in-flight downloads still run to completion since blocking I/O cannot be interrupted mid-flight
- 1bf4af9 - adds `max_workers` to `ScrapeConfig` (default 8, clamped 1-16 at the API boundary in `api.py`) and threads it through `run_download`

## API / logging

- cc0e29f - emits `log("info", ...)` events at each pipeline stage: mode start, cache load result, scrape/search item counts, cookies path, ffmpeg path, download start with target dir, and a final summary line showing successes, video count, and skipped count
- cc0e29f - the empty-result case ("no media found") now emits a `warn` log pointing at the likely causes (bad URL, expired cookies) instead of silently reporting a clean run

## State

- 244ffa2 - fixes the downloaded tile count: removes the incorrect `downloaded = event.current` assignment on download-phase progress events (which overcounted skipped files) and instead increments via `media` events, which fire only on confirmed successes

## Settings UI

- 1bf4af9 - adds a "Max Concurrent Downloads" number input (1-16) to SettingsDialog, persisted to localStorage under `maxWorkers` and forwarded to the backend via `RunPayload.max_workers`

## Console panel

- 6f4c66d - makes log message text selectable (`select-text` on container, `select-none` on timestamps and badges) so users can copy file paths or error text directly
- 6f4c66d - adds per-row hover highlight (`hover:bg-muted/70`) and `break-all` on message text for long paths and URLs
- a59cf4e - renames the download-phase log tag from `DL` to `OK` to better signal success
