### PR TITLE
Add multi-lingual UI support (English and Chinese)

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -5,6 +5,7 @@
     import ConfigPanel from '$lib/components/ConfigPanel.svelte';
     import ConsolePanel from '$lib/components/ConsolePanel.svelte';
     import { onBridgeReady, getApi } from '$lib/api';
+    import { i18n } from '$lib/i18n/index.svelte';
 
     let coreVersion = $state('unknown');
     async function loadCoreVersion() {
@@ -103,12 +104,12 @@
         <div class="flex gap-2">
             <div class="flex items-center gap-2">
                 <span class="size-2 rounded-full bg-green-500"></span>
-                <span>READY</span>
+                <span>{i18n.m.statusBar.ready}</span>
             </div>
             |
             <div class="flex items-center gap-2">
                 <span class="size-2 rounded-full bg-green-500"></span>
-                <span>FFMPEG</span>
+                <span>{i18n.m.statusBar.ffmpeg}</span>
             </div>
         </div>
 

--- a/frontend/src/lib/components/ConfigPanel.svelte
+++ b/frontend/src/lib/components/ConfigPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { cn } from '$lib/utils';
-    import { run, captionItems } from '$lib/state/run.svelte';
+    import { run, captionValues } from '$lib/state/run.svelte';
+    import { i18n } from '$lib/i18n/index.svelte';
     import { OptionRow, OptionGroup, OptionGroupSub } from '$lib/components/ui/option-row';
     import SettingsDialog from '$lib/components/SettingsDialog.svelte';
     import { Button } from '$lib/components/ui/button';
@@ -26,8 +27,9 @@
 
     const showLimit = $derived(run.mode !== 'download');
     const showBrowseSource = $derived(run.mode === 'download');
+    // run.caption is a plain string; index the localized caption map (cast) and fall back.
     const captionLabel = $derived(
-        captionItems.find((i) => i.value === run.caption)?.label ?? 'Select'
+        (i18n.m.config.captions as Record<string, string>)[run.caption] ?? i18n.m.common.select
     );
 
     const isRunning = $derived(runStatus.status === 'running');
@@ -155,34 +157,34 @@
                     class="cursor-pointer flex-1 gap-1.5 text-muted-foreground data-[state=on]:bg-muted data-[state=on]:text-foreground data-[state=on]:shadow-sm"
                 >
                     <Download class="size-3.5" />
-                    Scrape
+                    {i18n.m.mode.scrape}
                 </ToggleGroupItem>
                 <ToggleGroupItem
                     value="search"
                     class="cursor-pointer flex-1 gap-1.5 text-muted-foreground data-[state=on]:bg-muted data-[state=on]:text-foreground data-[state=on]:shadow-sm"
                 >
                     <Search class="size-3.5" />
-                    Search
+                    {i18n.m.mode.search}
                 </ToggleGroupItem>
                 <ToggleGroupItem
                     value="download"
                     class="cursor-pointer flex-1 gap-1.5 text-muted-foreground data-[state=on]:bg-muted data-[state=on]:text-foreground data-[state=on]:shadow-sm"
                 >
                     <FileDown class="size-3.5" />
-                    Download
+                    {i18n.m.mode.download}
                 </ToggleGroupItem>
             </ToggleGroup>
 
             <!-- Target -->
             <div class="flex flex-col gap-3">
-                {@render groupLabel('Target')}
+                {@render groupLabel(i18n.m.config.groups.target)}
                 <div class="flex flex-col gap-1.5">
                     <Label for="source"
                         >{run.mode === 'search'
-                            ? 'Search Query'
+                            ? i18n.m.config.sourceLabel.query
                             : run.mode === 'download'
-                              ? 'Cache File'
-                              : 'Source URL'}</Label
+                              ? i18n.m.config.sourceLabel.cacheFile
+                              : i18n.m.config.sourceLabel.url}</Label
                     >
                     <div class="flex">
                         <Input
@@ -211,7 +213,7 @@
                 </div>
                 <div class="flex gap-3">
                     <div class="flex flex-2 flex-col gap-1.5">
-                        <Label for="output">Output Directory</Label>
+                        <Label for="output">{i18n.m.config.outputDir}</Label>
                         <div class="flex">
                             <Input
                                 id="output"
@@ -230,7 +232,7 @@
                     </div>
                     {#if showLimit}
                         <div class="flex flex-1 flex-col gap-1.5">
-                            <Label for="limit">Limit</Label>
+                            <Label for="limit">{i18n.m.config.num}</Label>
                             <NumberInput id="limit" bind:value={run.limit} min={1} max={5000} />
                         </div>
                     {/if}
@@ -239,18 +241,18 @@
 
             <!-- Extraction options -->
             <div class="flex flex-col gap-3">
-                {@render groupLabel('Extraction Options')}
+                {@render groupLabel(i18n.m.config.groups.extraction)}
                 <div class="flex flex-col gap-2">
                     <OptionRow
-                        title="Fetch Videos"
-                        desc="Download HLS video segments and mux to MP4."
+                        title={i18n.m.config.fetchVideos.title}
+                        desc={i18n.m.config.fetchVideos.desc}
                     >
                         <Switch bind:checked={run.fetchVideos} />
                     </OptionRow>
 
                     <OptionRow
-                        title="Minimum Resolution"
-                        desc="Discard assets smaller than dimensions (0 disables)."
+                        title={i18n.m.config.minResolution.title}
+                        desc={i18n.m.config.minResolution.desc}
                     >
                         <div class="flex items-center gap-2">
                             <NumberInput bind:value={run.resW} min={0} class="w-28" />
@@ -260,22 +262,28 @@
                     </OptionRow>
 
                     <OptionRow
-                        title="Metadata Strategy"
-                        desc="Format for accompanying alt text/captions."
+                        title={i18n.m.config.metadataStrategy.title}
+                        desc={i18n.m.config.metadataStrategy.desc}
                     >
                         <Select.Root type="single" bind:value={run.caption}>
                             <Select.Trigger class="w-[150px]">{captionLabel}</Select.Trigger>
                             <Select.Content>
                                 <Select.Group>
-                                    {#each captionItems as item (item.value)}
-                                        <Select.Item value={item.value} label={item.label} />
+                                    {#each captionValues as value (value)}
+                                        <Select.Item
+                                            {value}
+                                            label={i18n.m.config.captions[value]}
+                                        />
                                     {/each}
                                 </Select.Group>
                             </Select.Content>
                         </Select.Root>
                     </OptionRow>
 
-                    <OptionRow title="Strict Alt-Text" desc="Drop assets lacking valid captions.">
+                    <OptionRow
+                        title={i18n.m.config.strictAlt.title}
+                        desc={i18n.m.config.strictAlt.desc}
+                    >
                         <Switch bind:checked={run.strictAlt} />
                     </OptionRow>
                 </div>
@@ -284,13 +292,13 @@
             <!-- Metadata cache (scrape/search only; download mode already has the records) -->
             {#if run.mode !== 'download'}
                 <div class="flex flex-col gap-3">
-                    {@render groupLabel('Metadata Cache')}
+                    {@render groupLabel(i18n.m.config.groups.metadataCache)}
                     <div class="flex flex-col gap-2">
                         <OptionGroup>
                             <OptionRow
                                 flat
-                                title="Save Metadata Cache"
-                                desc="Write scraped records to a JSON file for reuse in Download mode."
+                                title={i18n.m.config.saveCache.title}
+                                desc={i18n.m.config.saveCache.desc}
                             >
                                 <Switch bind:checked={run.saveCache} />
                             </OptionRow>
@@ -298,7 +306,7 @@
                             {#if run.saveCache}
                                 <OptionGroupSub>
                                     <div class="flex flex-col gap-1.5 p-3">
-                                        <Label for="cachePath">Cache Path</Label>
+                                        <Label for="cachePath">{i18n.m.config.cachePath}</Label>
                                         <div class="flex">
                                             <Input
                                                 id="cachePath"
@@ -317,13 +325,13 @@
                                             </Button>
                                         </div>
                                         <p class="text-xs text-muted-foreground">
-                                            Follows the output directory until you change it.
+                                            {i18n.m.config.cachePathHint}
                                         </p>
                                     </div>
                                     <OptionRow
                                         flat
-                                        title="Skip Download"
-                                        desc="Save metadata only; don't download media."
+                                        title={i18n.m.config.skipDownload.title}
+                                        desc={i18n.m.config.skipDownload.desc}
                                     >
                                         <Switch bind:checked={run.skipDownload} />
                                     </OptionRow>
@@ -342,12 +350,12 @@
         {#if isRunning}
             <Button variant="destructive" onclick={terminate}>
                 <Square />
-                Terminate
+                {i18n.m.config.terminate}
             </Button>
         {:else}
             <Button onclick={execute}>
                 <Play />
-                Execute
+                {i18n.m.config.execute}
             </Button>
         {/if}
     </div>

--- a/frontend/src/lib/components/ConsolePanel.svelte
+++ b/frontend/src/lib/components/ConsolePanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { cn } from '$lib/utils';
     import { runStatus, type LogLine } from '$lib/state/runStatus.svelte';
+    import { i18n } from '$lib/i18n/index.svelte';
     import { Progress } from '$lib/components/ui/progress';
     import { Badge } from '$lib/components/ui/badge';
     import { ScrollArea } from '$lib/components/ui/scroll-area';
@@ -33,10 +34,12 @@
     );
 
     const phaseLabel = $derived.by(() => {
-        if (runStatus.status === 'idle') return 'Idle';
-        if (runStatus.status === 'done') return 'Done';
-        if (runStatus.status === 'error') return 'Error';
-        return runStatus.phase === 'download' ? 'Downloading' : 'Scraping';
+        if (runStatus.status === 'idle') return i18n.m.console.phase.idle;
+        if (runStatus.status === 'done') return i18n.m.console.phase.done;
+        if (runStatus.status === 'error') return i18n.m.console.phase.error;
+        return runStatus.phase === 'download'
+            ? i18n.m.console.phase.downloading
+            : i18n.m.console.phase.scraping;
     });
 </script>
 
@@ -52,10 +55,10 @@
             >
                 {#if savedOnly}
                     <Save class="size-3" />
-                    Saved
+                    {i18n.m.console.saved}
                 {:else}
                     <Download class="size-3" />
-                    Downloaded
+                    {i18n.m.console.downloaded}
                 {/if}
             </span>
         </div>
@@ -67,7 +70,7 @@
                 class="flex items-center gap-1.5 text-[11px] font-semibold tracking-wide text-muted-foreground uppercase"
             >
                 <Film class="size-3" />
-                Videos
+                {i18n.m.console.videos}
             </span>
         </div>
     </div>

--- a/frontend/src/lib/components/SettingsDialog.svelte
+++ b/frontend/src/lib/components/SettingsDialog.svelte
@@ -8,7 +8,9 @@
         type FfmpegStatus,
         type CookieStatus
     } from '$lib/state/settings.svelte';
+    import { i18n, setLocale, localeOptions, type Locale } from '$lib/i18n/index.svelte';
     import * as Dialog from '$lib/components/ui/dialog';
+    import * as Select from '$lib/components/ui/select';
     import { Button } from '$lib/components/ui/button';
     import { Input } from '$lib/components/ui/input';
     import { NumberInput } from '$lib/components/ui/number-input';
@@ -18,6 +20,7 @@
     import InfoTooltip from '$lib/components/info-tooltip.svelte';
     import TooltipButton from '$lib/components/tooltip-button.svelte';
     import Settings from '@lucide/svelte/icons/settings';
+    import Languages from '@lucide/svelte/icons/languages';
     import KeyRound from '@lucide/svelte/icons/key-round';
     import Film from '@lucide/svelte/icons/film';
     import Gauge from '@lucide/svelte/icons/gauge';
@@ -28,21 +31,32 @@
     import LoaderCircle from '@lucide/svelte/icons/loader-circle';
     import CircleQuestionMark from '@lucide/svelte/icons/circle-question-mark';
 
-    const statusMeta: Record<FfmpegStatus, { label: string; class: string }> = {
-        found: { label: 'Found', class: 'bg-success/10 text-success' },
-        missing: { label: 'Not found', class: 'bg-destructive/10 text-destructive' },
-        checking: { label: 'Checking', class: 'bg-muted text-muted-foreground' },
-        unknown: { label: 'Unknown', class: 'bg-muted text-muted-foreground' }
+    // Badge color per status; the label is localized (i18n.settings.ffmpegStatus/cookieStatus).
+    const ffmpegStatusClass: Record<FfmpegStatus, string> = {
+        found: 'bg-success/10 text-success',
+        missing: 'bg-destructive/10 text-destructive',
+        checking: 'bg-muted text-muted-foreground',
+        unknown: 'bg-muted text-muted-foreground'
     };
-    const status = $derived(statusMeta[settings.ffmpegStatus]);
+    const status = $derived({
+        label: i18n.m.settings.ffmpegStatus[settings.ffmpegStatus],
+        class: ffmpegStatusClass[settings.ffmpegStatus]
+    });
 
-    const cookieMeta: Record<CookieStatus, { label: string; class: string }> = {
-        valid: { label: 'Valid', class: 'bg-success/10 text-success' },
-        expired: { label: 'Expired', class: 'bg-destructive/10 text-destructive' },
-        checking: { label: 'Checking', class: 'bg-muted text-muted-foreground' },
-        unknown: { label: 'Unknown', class: 'bg-muted text-muted-foreground' }
+    const cookieStatusClass: Record<CookieStatus, string> = {
+        valid: 'bg-success/10 text-success',
+        expired: 'bg-destructive/10 text-destructive',
+        checking: 'bg-muted text-muted-foreground',
+        unknown: 'bg-muted text-muted-foreground'
     };
-    const cookie = $derived(cookieMeta[settings.cookieStatus]);
+    const cookie = $derived({
+        label: i18n.m.settings.cookieStatus[settings.cookieStatus],
+        class: cookieStatusClass[settings.cookieStatus]
+    });
+
+    const currentLocaleName = $derived(
+        localeOptions.find((o) => o.value === i18n.locale)?.name ?? i18n.locale
+    );
 
     function formatExpiry(unixSeconds: number): string {
         return new Date(unixSeconds * 1000).toLocaleDateString(undefined, {
@@ -109,33 +123,57 @@
         {#snippet child({ props })}
             <Button {...props} variant="outline" size="sm">
                 <Settings />
-                Settings
+                {i18n.m.settings.button}
             </Button>
         {/snippet}
     </Dialog.Trigger>
 
     <Dialog.Content class="sm:max-w-lg">
         <Dialog.Header>
-            <Dialog.Title>Settings</Dialog.Title>
-            <Dialog.Description>Global configuration shared across all modes.</Dialog.Description>
+            <Dialog.Title>{i18n.m.settings.title}</Dialog.Title>
+            <Dialog.Description>{i18n.m.settings.description}</Dialog.Description>
         </Dialog.Header>
 
         <div class="flex min-w-0 flex-col gap-6 text-xs">
+            <!-- Language -->
+            <section class="flex flex-col gap-3">
+                {@render sectionLabel(Languages, i18n.m.settings.sections.language)}
+                <div class="flex flex-col gap-1.5">
+                    <Label for="set-locale">{i18n.m.settings.language.label}</Label>
+                    <Select.Root
+                        type="single"
+                        value={i18n.locale}
+                        onValueChange={(value) => setLocale(value as Locale)}
+                    >
+                        <Select.Trigger id="set-locale" class="w-full">
+                            {currentLocaleName}
+                        </Select.Trigger>
+                        <Select.Content>
+                            <Select.Group>
+                                {#each localeOptions as option (option.value)}
+                                    <Select.Item value={option.value} label={option.name} />
+                                {/each}
+                            </Select.Group>
+                        </Select.Content>
+                    </Select.Root>
+                </div>
+            </section>
+
+            <Separator />
+
             <!-- Authentication -->
             <section class="flex flex-col gap-3">
-                {@render sectionLabel(KeyRound, 'Authentication')}
+                {@render sectionLabel(KeyRound, i18n.m.settings.sections.auth)}
                 <div class="flex flex-col gap-1.5">
                     <div class="flex items-center gap-1.5">
-                        <Label for="set-cookies">Session Cookies File</Label>
-                        <InfoTooltip
-                            text="Shared by Scrape and Search. Required only for private boards; public endpoints operate without session state."
-                        />
+                        <Label for="set-cookies">{i18n.m.settings.cookies.label}</Label>
+                        <InfoTooltip text={i18n.m.settings.cookies.tooltip} />
                     </div>
                     <div class="flex">
                         <Input
                             id="set-cookies"
                             bind:value={settings.cookies}
-                            placeholder="No file loaded"
+                            placeholder={i18n.m.settings.cookies.placeholder}
                             class="flex-1 rounded-r-none border-r-0 font-mono"
                         />
                         <Button
@@ -146,7 +184,7 @@
                             <FolderOpen />
                         </Button>
                         <TooltipButton
-                            tooltip="Capture a new cookies from Pinterest by logging in through an embedded browser window."
+                            tooltip={i18n.m.settings.cookies.captureTooltip}
                             variant="outline"
                             class="shrink-0 rounded-l-none"
                             onclick={captureCookies}
@@ -176,15 +214,17 @@
                             </Badge>
                             {#if settings.cookieStatus === 'expired'}
                                 <span class="text-destructive"
-                                    >Session expired - recapture to refresh.</span
+                                    >{i18n.m.settings.cookieMessage.expired}</span
                                 >
                             {:else if settings.cookieStatus === 'valid' && settings.cookieExpiry}
                                 <span class="text-muted-foreground"
-                                    >Valid until {formatExpiry(settings.cookieExpiry)}</span
+                                    >{i18n.m.settings.cookieMessage.validUntil(
+                                        formatExpiry(settings.cookieExpiry)
+                                    )}</span
                                 >
                             {:else if settings.cookieStatus === 'unknown'}
                                 <span class="text-muted-foreground"
-                                    >No expiry info - validity unknown.</span
+                                    >{i18n.m.settings.cookieMessage.unknownExpiry}</span
                                 >
                             {/if}
                         </div>
@@ -197,10 +237,8 @@
             <!-- Video / FFmpeg -->
             <section class="flex flex-col gap-3">
                 <div class="flex items-center gap-1.5">
-                    {@render sectionLabel(Film, 'Video / FFmpeg')}
-                    <InfoTooltip
-                        text="Required to remux HLS video into MP4. Without it, videos are saved as raw .ts segments."
-                    />
+                    {@render sectionLabel(Film, i18n.m.settings.sections.ffmpeg)}
+                    <InfoTooltip text={i18n.m.settings.ffmpeg.tooltip} />
                 </div>
                 <div
                     class="flex items-center justify-between gap-3 rounded-md border border-border bg-card p-3"
@@ -219,17 +257,17 @@
                                 {/if}
                                 {status.label}
                             </Badge>
-                            <span class="text-muted-foreground">FFmpeg</span>
+                            <span class="text-muted-foreground">{i18n.m.settings.ffmpeg.label}</span>
                         </div>
                         <span
                             class="truncate font-mono text-[11px] text-muted-foreground/70"
                             title={settings.ffmpegResolved}
                         >
-                            {settings.ffmpegResolved || 'Not resolved'}
+                            {settings.ffmpegResolved || i18n.m.settings.ffmpeg.notResolved}
                         </span>
                     </div>
                     <TooltipButton
-                        tooltip="Re-check FFmpeg availability"
+                        tooltip={i18n.m.settings.ffmpeg.recheckTooltip}
                         variant="outline"
                         size="sm"
                         class="shrink-0"
@@ -239,13 +277,13 @@
                     </TooltipButton>
                 </div>
                 <div class="flex flex-col gap-1.5">
-                    <Label for="set-ffmpeg">Custom FFmpeg Path</Label>
+                    <Label for="set-ffmpeg">{i18n.m.settings.ffmpeg.customPathLabel}</Label>
 
                     <div class="flex">
                         <Input
                             id="set-ffmpeg"
                             bind:value={settings.ffmpegPath}
-                            placeholder="Leave empty to use PATH"
+                            placeholder={i18n.m.settings.ffmpeg.customPathPlaceholder}
                             class="flex-1 rounded-r-none border-r-0 font-mono"
                         />
                         <Button
@@ -263,14 +301,12 @@
 
             <!-- Network -->
             <section class="flex flex-col gap-3">
-                {@render sectionLabel(Gauge, 'Network Defaults')}
+                {@render sectionLabel(Gauge, i18n.m.settings.sections.network)}
                 <div class="flex gap-3">
                     <div class="flex flex-1 flex-col gap-1.5">
                         <div class="flex items-center gap-1.5">
-                            <Label for="set-delay">Request Delay (s)</Label>
-                            <InfoTooltip
-                                text="Applied per request. Higher delay is gentler on Pinterest and reduces rate-limiting."
-                            />
+                            <Label for="set-delay">{i18n.m.settings.network.delay.label}</Label>
+                            <InfoTooltip text={i18n.m.settings.network.delay.tooltip} />
                         </div>
                         <NumberInput
                             id="set-delay"
@@ -281,10 +317,8 @@
                     </div>
                     <div class="flex flex-1 flex-col gap-1.5">
                         <div class="flex items-center gap-1.5">
-                            <Label for="set-timeout">Timeout (s)</Label>
-                            <InfoTooltip
-                                text="Maximum wait time per request before it is aborted. Applied to every run."
-                            />
+                            <Label for="set-timeout">{i18n.m.settings.network.timeout.label}</Label>
+                            <InfoTooltip text={i18n.m.settings.network.timeout.tooltip} />
                         </div>
                         <NumberInput
                             id="set-timeout"
@@ -296,10 +330,8 @@
                 </div>
                 <div class="flex flex-col gap-1.5">
                     <div class="flex items-center gap-1.5">
-                        <Label for="set-max-workers">Max Concurrent Downloads</Label>
-                        <InfoTooltip
-                            text="How many files download in parallel. Higher is faster but higher risk of rate-limiting. (1-16, defaults to 8)"
-                        />
+                        <Label for="set-max-workers">{i18n.m.settings.network.maxWorkers.label}</Label>
+                        <InfoTooltip text={i18n.m.settings.network.maxWorkers.tooltip} />
                     </div>
                     <NumberInput
                         id="set-max-workers"

--- a/frontend/src/lib/i18n/en.ts
+++ b/frontend/src/lib/i18n/en.ts
@@ -1,0 +1,166 @@
+// English is the source of truth for every user-facing string.
+
+// Conventions:
+// - Group keys by the UI region they appear in (mode / config / settings / console / ...).
+// - Keep paired strings together: an option's `title` and `desc` live in one object so
+//   neither can go missing without the other.
+// - Interpolated strings are functions, not "{placeholder}" templates, so the argument is
+//   type-checked at every call site.
+// - Technical tokens (log tags, file paths, example URLs) stay inline in components; they
+//   are not translated.
+
+export const en = {
+	common: {
+		select: "Select",
+	},
+	mode: {
+		scrape: "Scrape",
+		search: "Search",
+		download: "Download",
+	},
+	config: {
+		groups: {
+			target: "Target",
+			extraction: "Extraction Options",
+			metadataCache: "Metadata Cache",
+		},
+		// The single source field is relabelled per mode.
+		sourceLabel: {
+			url: "Source URL",
+			query: "Search Query",
+			cacheFile: "Cache File",
+		},
+		outputDir: "Output Directory",
+		num: "Max Items",
+		fetchVideos: {
+			title: "Fetch Videos",
+			desc: "Download HLS video segments and mux to MP4.",
+		},
+		minResolution: {
+			title: "Minimum Resolution",
+			desc: "Discard assets smaller than dimensions (0 disables).",
+		},
+		metadataStrategy: {
+			title: "Metadata Strategy",
+			desc: "Format for accompanying alt text/captions.",
+		},
+		strictAlt: {
+			title: "Strict Alt-Text",
+			desc: "Drop assets lacking valid captions.",
+		},
+		// Keyed by the caption `value` in run.svelte.ts (captionValues).
+		captions: {
+			none: "None",
+			txt: "TXT Sidecar",
+			json: "JSON Sidecar",
+			metadata: "Embed EXIF",
+		},
+		saveCache: {
+			title: "Save Metadata Cache",
+			desc: "Write scraped records to a JSON file for reuse in Download mode.",
+		},
+		cachePath: "Cache Path",
+		cachePathHint: "Follows the output directory until you change it.",
+		skipDownload: {
+			title: "Skip Download",
+			desc: "Save metadata only; don't download media.",
+		},
+		execute: "Execute",
+		terminate: "Terminate",
+	},
+	settings: {
+		button: "Settings",
+		title: "Settings",
+		description: "Global configuration shared across all modes.",
+		sections: {
+			language: "Language",
+			auth: "Authentication",
+			ffmpeg: "Video / FFmpeg",
+			network: "Network Defaults",
+		},
+		language: {
+			label: "Interface Language",
+		},
+		cookies: {
+			label: "Session Cookies File",
+			tooltip:
+				"Shared by Scrape and Search. Required only for private boards; public endpoints operate without session state.",
+			placeholder: "No file loaded",
+			captureTooltip:
+				"Capture a new cookies from Pinterest by logging in through an embedded browser window.",
+		},
+		cookieStatus: {
+			valid: "Valid",
+			expired: "Expired",
+			checking: "Checking",
+			unknown: "Unknown",
+		},
+		cookieMessage: {
+			expired: "Session expired - recapture to refresh.",
+			validUntil: (date: string) => `Valid until ${date}`,
+			unknownExpiry: "No expiry info - validity unknown.",
+		},
+		ffmpeg: {
+			label: "FFmpeg",
+			tooltip:
+				"Required to remux HLS video into MP4. Without it, videos are saved as raw .ts segments.",
+			notResolved: "Not resolved",
+			recheckTooltip: "Re-check FFmpeg availability",
+			customPathLabel: "Custom FFmpeg Path",
+			customPathPlaceholder: "Leave empty to use PATH",
+		},
+		ffmpegStatus: {
+			found: "Found",
+			missing: "Not found",
+			checking: "Checking",
+			unknown: "Unknown",
+		},
+		network: {
+			delay: {
+				label: "Request Delay (s)",
+				tooltip:
+					"Applied per request. Higher delay is gentler on Pinterest and reduces rate-limiting.",
+			},
+			timeout: {
+				label: "Timeout (s)",
+				tooltip:
+					"Maximum wait time per request before it is aborted. Applied to every run.",
+			},
+			maxWorkers: {
+				label: "Max Concurrent Downloads",
+				tooltip:
+					"How many files download in parallel. Higher is faster but higher risk of rate-limiting. (1-16, defaults to 8)",
+			},
+		},
+	},
+	console: {
+		saved: "Saved",
+		downloaded: "Downloaded",
+		videos: "Videos",
+		phase: {
+			idle: "Idle",
+			done: "Done",
+			error: "Error",
+			downloading: "Downloading",
+			scraping: "Scraping",
+		},
+	},
+	statusBar: {
+		ready: "READY",
+		ffmpeg: "FFMPEG",
+	},
+};
+
+// The translation contract. Other locales must match this shape (see PartialMessages).
+export type Messages = typeof en;
+
+// A locale may translate any subset of the tree; omitted keys fall back to English at
+// runtime (see mergeMessages in index.svelte.ts). Functions and primitives are leaves:
+// they are replaced wholesale, never merged, so an interpolation function stays callable.
+export type PartialMessages<T> = {
+	[K in keyof T]?: T[K] extends (...args: never[]) => unknown
+		? T[K]
+		: T[K] extends object
+			? PartialMessages<T[K]>
+			: T[K];
+};

--- a/frontend/src/lib/i18n/index.svelte.ts
+++ b/frontend/src/lib/i18n/index.svelte.ts
@@ -1,0 +1,81 @@
+// Reactive i18n: holds the active locale, persists it, and exposes the merged message tree
+// as `i18n.m`. English is the fallback locale; a partial translation is overlaid on top of
+// it so untranslated keys still render (see mergeMessages). Adding a language means
+// importing its file and adding one entry to `locales` -- nothing else changes.
+
+import { en } from "./en";
+import type { Messages, PartialMessages } from "./en";
+
+export type { Messages } from "./en";
+
+export type Locale = "en" | "zh";
+
+interface LocaleEntry {
+	readonly name: string; // endonym shown in the language picker
+	readonly messages: PartialMessages<Messages>;
+}
+
+import { zh } from "./zh";
+
+export const locales: Record<Locale, LocaleEntry> = {
+	en: { name: "English", messages: en },
+	zh: { name: "中文", messages: zh },
+};
+
+// Picker-ready list derived from the registry; order follows declaration order above.
+export const localeOptions: { value: Locale; name: string }[] = (
+	Object.keys(locales) as Locale[]
+).map((value) => ({ value, name: locales[value].name }));
+
+const LOCALE_KEY = "pdl.locale";
+
+function loadInitialLocale(): Locale {
+	const saved = localStorage.getItem(LOCALE_KEY);
+	// `in` confirms membership; the cast is safe because we just checked the key exists.
+	return saved !== null && saved in locales ? (saved as Locale) : "en";
+}
+
+function isMergeable(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// Overlay a partial translation onto the English base: recurse into nested objects, fall
+// back to English for any key the translation omits. Functions and primitives are leaves
+// (replaced wholesale), so interpolation functions remain callable.
+function mergeMessages<T>(base: T, override: PartialMessages<T>): T {
+	// Rebuilt key-by-key from a shallow clone; cast at the boundary, returned as T below.
+	const result = { ...(base as Record<string, unknown>) };
+	for (const key of Object.keys(override)) {
+		const overrideValue = (override as Record<string, unknown>)[key];
+		if (overrideValue === undefined) continue;
+		const baseValue = result[key];
+		result[key] =
+			isMergeable(baseValue) && isMergeable(overrideValue)
+				? mergeMessages(baseValue, overrideValue)
+				: overrideValue;
+	}
+	return result as T;
+}
+
+let locale = $state<Locale>(loadInitialLocale());
+
+// Recomputed only when the locale changes; English is returned as-is (no merge needed).
+const messages = $derived(
+	locale === "en" ? en : mergeMessages(en, locales[locale].messages),
+);
+
+// Read-only reactive accessor. Components read `i18n.m.<section>.<key>`; every access
+// re-runs on locale change because `messages` is a derived rune read through the getter.
+export const i18n = {
+	get locale(): Locale {
+		return locale;
+	},
+	get m(): Messages {
+		return messages;
+	},
+};
+
+export function setLocale(next: Locale): void {
+	locale = next;
+	localStorage.setItem(LOCALE_KEY, next);
+}

--- a/frontend/src/lib/i18n/zh.ts
+++ b/frontend/src/lib/i18n/zh.ts
@@ -1,0 +1,147 @@
+import type { Messages, PartialMessages } from "./en";
+
+// Chinese translation. This file is intentionally PARTIAL: any key omitted here falls back
+// to the English string at runtime, so you can translate incrementally. To expand it,
+// follow the shape of `en` in ./en.ts and fill in more keys -- TypeScript checks that each
+// key you add exists in English and has the right type.
+export const zh: PartialMessages<Messages> = {
+	common: {
+		select: "选择",
+	},
+	mode: {
+		scrape: "抓取",
+		search: "搜索",
+		download: "下载",
+	},
+	config: {
+		groups: {
+			target: "目标",
+			extraction: "提取选项",
+			metadataCache: "元数据缓存",
+		},
+		// The single source field is relabelled per mode.
+		sourceLabel: {
+			url: "目标链接",
+			query: "搜索关键词",
+			cacheFile: "缓存文件",
+		},
+		outputDir: "输出目录",
+		num: "最大数量",
+		fetchVideos: {
+			title: "下载视频",
+			desc: "下载 HLS 视频片段并合并为 MP4。",
+		},
+		minResolution: {
+			title: "最小分辨率",
+			desc: "过滤小于该尺寸的图片, 设为 0 则关闭。",
+		},
+		metadataStrategy: {
+			title: "文字描述",
+			desc: "如何保存图片的标题、描述等文字信息。",
+		},
+		strictAlt: {
+			title: "过滤无描述内容",
+			desc: "仅下载包含标题或描述的图片, 舍弃无文字信息的内容。",
+		},
+		// Keyed by the caption `value` in run.svelte.ts (captionValues).
+		captions: {
+			none: "不保存",
+			txt: "保存为 TXT",
+			json: "保存为 JSON",
+			metadata: "嵌入 EXIF",
+		},
+		saveCache: {
+			title: "保存元数据",
+			desc: "将抓取结果保存为 JSON 文件, 供下载模式复用。",
+		},
+		cachePath: "缓存文件路径",
+		cachePathHint: "跟随输出目录, 手动修改后不再自动同步。",
+		skipDownload: {
+			title: "跳过下载",
+			desc: "仅保存元数据, 不下载媒体文件。",
+		},
+		execute: "执行",
+		terminate: "终止",
+	},
+	settings: {
+		button: "设置",
+		title: "设置",
+		description: "全局配置, 所有模式共用。",
+		sections: {
+			language: "语言",
+			auth: "认证",
+			ffmpeg: "视频 / FFmpeg",
+			network: "网络设置",
+		},
+		language: {
+			label: "界面语言",
+		},
+		cookies: {
+			label: "Cookie 文件",
+			tooltip:
+				"抓取与搜索模式共用。公开内容无需登录, 仅访问私有画板时需要。",
+			placeholder: "未选择文件",
+			captureTooltip:
+				"通过内嵌浏览器登录 Pinterest, 自动获取 Cookie。",
+		},
+		cookieStatus: {
+			valid: "有效",
+			expired: "已过期",
+			checking: "检查中",
+			unknown: "未知",
+		},
+		cookieMessage: {
+			expired: "登录已过期, 请重新获取。",
+			validUntil: (date: string) => `有效期至 ${date}`,
+			unknownExpiry: "无法检测有效期, 状态未知。",
+		},
+		ffmpeg: {
+			label: "FFmpeg",
+			tooltip:
+				"用于将 HLS 视频合并为 MP4。若未检测到, 视频将以原始 .ts 片段保存。",
+			notResolved: "未找到",
+			recheckTooltip: "重新检测 FFmpeg",
+			customPathLabel: "自定义路径",
+			customPathPlaceholder: "留空则使用系统 PATH",
+		},
+		ffmpegStatus: {
+			found: "已找到",
+			missing: "未找到",
+			checking: "检查中",
+			unknown: "未知",
+		},
+		network: {
+			delay: {
+				label: "请求间隔（秒）",
+				tooltip:
+					"每次请求之间的等待时间。间隔越长对 Pinterest 越友好, 可降低限流风险。",
+			},
+			timeout: {
+				label: "请求超时（秒）",
+				tooltip:
+					"单个请求的最长等待时间, 超时后自动中止。",
+			},
+			maxWorkers: {
+				label: "最大并发下载数",
+				tooltip:
+					"同时下载的文件数量。数值越大速度越快, 但限流风险也越高。范围 1-16, 默认 8。",
+			},
+		},
+	},
+	console: {
+		saved: "已缓存",
+		downloaded: "已下载",
+		videos: "视频",
+		phase: {
+			idle: "空闲",
+			done: "完成",
+			error: "错误",
+			downloading: "下载中",
+			scraping: "抓取中",
+		},
+	},
+	statusBar: {
+		ready: "就绪",
+		ffmpeg: "FFMPEG",
+	},
+};

--- a/frontend/src/lib/state/run.svelte.ts
+++ b/frontend/src/lib/state/run.svelte.ts
@@ -35,9 +35,5 @@ export const run = $state<RunConfig>({
 	skipDownload: false,
 });
 
-export const captionItems: { value: string; label: string }[] = [
-	{ value: "none", label: "None" },
-	{ value: "txt", label: "TXT Sidecar" },
-	{ value: "json", label: "JSON Sidecar" },
-	{ value: "metadata", label: "Embed EXIF" },
-];
+// Caption strategy values. Labels are localized via i18n (config.captions, keyed by value).
+export const captionValues = ["none", "txt", "json", "metadata"] as const;


### PR DESCRIPTION
## Why

All user-facing strings were hardcoded in English, making the app inaccessible to non-English speakers. This introduces a reactive i18n layer with English and Chinese as the first two supported locales; the active locale persists to `localStorage` and is switchable from Settings without a reload.


## i18n

- 564a294 - adds `frontend/src/lib/i18n/en.ts` as the source-of-truth string catalog; exports `Messages` (the full type) and `PartialMessages<T>` (a deep-partial helper) so other locales are type-checked against it at compile time.
- 564a294 - adds `frontend/src/lib/i18n/zh.ts` as a partial Chinese translation; any key omitted here falls back to the English value at runtime, so translation can be incremental.
- 564a294 - adds `frontend/src/lib/i18n/index.svelte.ts` with a Svelte-rune-based reactive store (`i18n.locale`, `i18n.m`); `mergeMessages` recursively overlays the active locale onto the English base and `setLocale` persists the choice to `localStorage`.
- 564a294 - wires `i18n.m.*` into every component: `App.svelte` (status bar), `ConfigPanel.svelte` (mode toggles, all option labels and descriptions, action buttons), `ConsolePanel.svelte` (phase labels, download/save counters), and `SettingsDialog.svelte` (all labels, tooltips, placeholders, cookie expiry message).
- 564a294 - adds a Language picker section at the top of `SettingsDialog.svelte` using the existing `Select` component and `localeOptions` from the i18n registry.
- 564a294 - replaces `captionItems` (hardcoded `{value, label}` pairs) in `run.svelte.ts` with plain `captionValues`; labels now come from `i18n.m.config.captions` keyed by value, keeping all translatable text in one place.


## Notes

Interpolated strings that embed runtime values (e.g. cookie expiry date) are typed functions (`(date: string) => string`) rather than `{placeholder}` templates, so the compiler catches mismatched arguments at every call site.

The `statusMeta` objects in `SettingsDialog.svelte` were split into a CSS-class map (`ffmpegStatusClass`, `cookieStatusClass`) and a localized label lookup; CSS class strings are not translated and must not enter the message tree.

Adding a third language only requires a new partial file and one entry in the `locales` registry in `index.svelte.ts` -- no component changes needed.
