### PR TITLE
feat(i18n): detect system language as default locale

### DIFF
--- a/frontend/src/lib/i18n/index.svelte.ts
+++ b/frontend/src/lib/i18n/index.svelte.ts
@@ -31,8 +31,9 @@ const LOCALE_KEY = "pdl.locale";
 
 function loadInitialLocale(): Locale {
 	const saved = localStorage.getItem(LOCALE_KEY);
-	// `in` confirms membership; the cast is safe because we just checked the key exists.
-	return saved !== null && saved in locales ? (saved as Locale) : "en";
+	if (saved !== null && saved in locales) return saved as Locale;
+	const sys = navigator.language.split("-")[0];
+	return sys in locales ? (sys as Locale) : "en";
 }
 
 function isMergeable(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## Why

The app previously hardcoded English as the default locale for all users, ignoring the language already set in their OS or browser. Users whose system language is supported (currently Chinese) had to manually switch every time on a fresh install.


## i18n

- d8754fb - `loadInitialLocale` in `frontend/src/lib/i18n/index.svelte.ts` now reads `navigator.language`, strips the region subtag, and maps it to a supported locale before falling back to English. A stored user preference still takes priority over the detected language.
